### PR TITLE
Improves the styles so the vessel panel doesn't overlap any other UI

### DIFF
--- a/app/styles/components/c_layer_panel.scss
+++ b/app/styles/components/c_layer_panel.scss
@@ -4,7 +4,7 @@
   font-family: $font-family-primary;
   position: absolute;
   background: $color9;
-  z-index: 9;
+  z-index: 10;
   right: 0;
   background-color: $color12;
   width: 320px;

--- a/app/styles/components/c_map.scss
+++ b/app/styles/components/c_map.scss
@@ -161,6 +161,6 @@ $corporateColor: #233e76;
 }
 
 .map_container {
-  height: calc(100% - 100px);;
+  height: calc(100% - 140px);;
   position: relative;
 }

--- a/app/styles/components/c_vessel_panel.scss
+++ b/app/styles/components/c_vessel_panel.scss
@@ -8,7 +8,9 @@
   right: 0;
   background-color: $color5;
   width: 320px;
-  top: 450px;
+  bottom: 130px;
+  max-height: calc(100% - 391px);
+  overflow-y: auto;
   max-width: 320px;
   box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.5);
   color: $white;

--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -17,6 +17,7 @@
 * {
   margin: 0;
   padding: 0;
+  box-sizing: border-box;
 }
 
 html {


### PR DESCRIPTION
This PR changes the position of the vessel panel. Now it doesn't overlap any other UI elements and is vertically scrollable if the height of the device is small. Additionally, when it would be displayed behind the "layer" panel when expanded.