### PR TITLE
date pickers

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,6 +12,6 @@
   <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick-theme.css"/>
 </head>
 <body>
-<div id="app"></div>
+<div id="app" style="height: 100%"></div>
 </body>
 </html>

--- a/app/src/components/app.jsx
+++ b/app/src/components/app.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import css from '../../styles/index.scss';
 
 const ACCESS_TOKEN_REGEX = /#access_token=([a-zA-Z0-9.\-\_]*)(&[a-z=])?/g;
 
@@ -18,7 +19,7 @@ class App extends Component {
 
   render() {
     return (
-      <div>
+      <div className={css['full-height-container']}>
         {this.props.loading && <div>Loading....</div>}
         {this.props.children}
       </div>

--- a/app/src/components/map/DatePicker.jsx
+++ b/app/src/components/map/DatePicker.jsx
@@ -1,74 +1,48 @@
 import React, { Component } from 'react';
-import map from '../../../styles/index.scss';
+import moment from 'moment';
+import ReactDatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
 
 class DatePicker extends Component {
   constructor(props) {
     super(props);
-    this.onDatePickerChange = this.onDatePickerChange.bind(this);
+    this.onChange = this.onChange.bind(this);
   }
 
-  onDatePickerChange(e) {
-    const start = (e.target.id === 'inner_extent_start') ? new Date(e.target.value) : this.props.start;
-    const end = (e.target.id === 'inner_extent_end') ? new Date(e.target.value) : this.props.end;
-    this.props.onDatePickerChange([start, end]);
+
+  onChange(m) {
+    // convert moment to date
+    this.props.onChange(m.clone().toDate());
   }
 
   render() {
     return (
-      <div className={map.date_inputs}>
-        <label htmlFor="inner_extent_start">
-        Start date
-          <input
-            type="date"
-            id="inner_extent_start"
-            value={this.props.start.toISOString().slice(0, 10)}
-            min={this.props.startMin.toISOString().slice(0, 10)}
-            max={this.props.startMax.toISOString().slice(0, 10)}
-            onChange={this.onDatePickerChange}
-          />
-        </label>
-        <label htmlFor="inner_extent_end">
-          End date
-          <input
-            type="date"
-            id="inner_extent_end"
-            value={this.props.end.toISOString().slice(0, 10)}
-            min={this.props.endMin.toISOString().slice(0, 10)}
-            max={this.props.endMax.toISOString().slice(0, 10)}
-            onChange={this.onDatePickerChange}
-          />
-        </label>
+      <div>
+        <ReactDatePicker
+          selected={moment(this.props.selected)}
+          minDate={moment(this.props.minDate)}
+          maxDate={moment(this.props.maxDate)}
+          onChange={this.onChange}
+        />
       </div>
     );
   }
 }
 
 DatePicker.propTypes = {
-  onDatePickerChange: React.PropTypes.func,
+  onChange: React.PropTypes.func,
   /**
-   * Current start date set (a Date object)
+   * Current  date set (a Date object)
    */
-  start: React.PropTypes.object,
-  /**
-   * Current end date set (a Date object)
-   */
-  end: React.PropTypes.object,
+  selected: React.PropTypes.object,
   /**
    * Minimum allowed start date (a Date object).
    */
-  startMin: React.PropTypes.object,
+  minDate: React.PropTypes.object,
   /**
-   * Maximum allowed start date (a Date object). Depends on the inner extent start date.
+   * Maximum allowed start date (a Date object).
    */
-  startMax: React.PropTypes.object,
-  /**
-   * Minimum allowed end date (a Date object). Depends on the inner extent end date.
-   */
-  endMin: React.PropTypes.object,
-  /**
-   * Maximum allowed end date (a Date object).
-   */
-  endMax: React.PropTypes.object
+  maxDate: React.PropTypes.object
 };
 
 export default DatePicker;

--- a/app/src/components/map/Timeline.jsx
+++ b/app/src/components/map/Timeline.jsx
@@ -34,7 +34,8 @@ class Timeline extends Component {
 
   constructor(props) {
     super(props);
-    this.onDatePickerChange = this.onDatePickerChange.bind(this);
+    this.onStartDatePickerChange = this.onStartDatePickerChange.bind(this);
+    this.onEndDatePickerChange = this.onEndDatePickerChange.bind(this);
     this.state = {
       outerExtent: TIMELINE_TOTAL_DATE_EXTENT
     };
@@ -287,9 +288,15 @@ class Timeline extends Component {
     this.enableInnerBrush();
   }
 
-  onDatePickerChange(outerExtent) {
+  onStartDatePickerChange(startDate) {
     this.setState({
-      outerExtent
+      outerExtent: [startDate, this.state.outerExtent[1]]
+    });
+  }
+
+  onEndDatePickerChange(endDate) {
+    this.setState({
+      outerExtent: [this.state.outerExtent[0], endDate]
     });
   }
 
@@ -297,13 +304,16 @@ class Timeline extends Component {
     return (
       <div>
         <DatePicker
-          onDatePickerChange={this.onDatePickerChange}
-          start={this.state.outerExtent[0]}
-          end={this.state.outerExtent[1]}
-          startMin={TIMELINE_TOTAL_DATE_EXTENT[0]}
-          startMax={this.props.filters.timelineInnerExtent[0]}
-          endMin={this.props.filters.timelineInnerExtent[1]}
-          endMax={TIMELINE_TOTAL_DATE_EXTENT[1]}
+          selected={this.state.outerExtent[0]}
+          minDate={TIMELINE_TOTAL_DATE_EXTENT[0]}
+          maxDate={this.props.filters.timelineInnerExtent[0]}
+          onChange={this.onStartDatePickerChange}
+        />
+        <DatePicker
+          selected={this.state.outerExtent[1]}
+          minDate={this.props.filters.timelineInnerExtent[1]}
+          maxDate={TIMELINE_TOTAL_DATE_EXTENT[1]}
+          onChange={this.onEndDatePickerChange}
         />
         <div id="timeline_svg_container" />
       </div>

--- a/app/styles/_base.scss
+++ b/app/styles/_base.scss
@@ -1,3 +1,5 @@
+@import 'settings';
+
 *, *:before, *:after {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
@@ -10,4 +12,9 @@ html, body {
   font-weight: $font-weight-normal;
   margin: 0;
   padding: 0;
+}
+
+.full-height-container,
+body > div > div > div { // FIXME: add .full-height-container to each page root div
+  height: 100%;
 }

--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -1,5 +1,6 @@
 @charset "utf-8";
 /*Base*/
+@import 'base';
 @import 'base/normalize.scss';
 @import 'base/slick.scss';
 @import 'base/text.scss';
@@ -29,7 +30,4 @@ body {
   margin: 0;
   padding: 0;
   height: 100%;
-  > div, > div > div, > div > div > div {
-    height: 100%;
-  }
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -61,6 +61,10 @@ const webpackConfig = {
       {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract('css?sourceMap&modules&importLoaders=1&localI‌​dentName=[name]__[local]___[hash:base64:5]!sass?sourceMap')
+      },
+      {
+        test: /\.css$/,
+        loader: 'style-loader!css-loader'
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -43,10 +43,12 @@
     "jquery": "^3.1.0",
     "json-loader": "^0.5.4",
     "lodash": "^4.13.1",
+    "moment": "^2.14.1",
     "morgan": "^1.7.0",
     "node-sass": "^3.7.0",
     "pretty-error": "^2.0.0",
     "react": "^15.0.2",
+    "react-datepicker": "^0.28.2",
     "react-dom": "^15.0.2",
     "react-draggable": "^2.1.2",
     "react-google-maps": "^4.11.0",
@@ -65,12 +67,14 @@
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
+    "css-loader": "^0.23.1",
     "eslint": "^3.2.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.12.0",
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^5.2.2",
     "sass-lint": "^1.8.2",
+    "style-loader": "^0.13.1",
     "svg-react-loader": "^0.3.7"
   },
   "engines": {


### PR DESCRIPTION
Adds full date pickers to the timeline.
![screen shot 2016-08-03 at 16 55 50](https://cloud.githubusercontent.com/assets/1583415/17370137/386e7de0-599b-11e6-9a20-96b070e97393.png)

Notes:
- uses https://github.com/Hacker0x01/react-datepicker, which has a de facto dependency to moment.js. Eventually we could swap all our dates to moment (except in d3), could simplify the code a bit in Timeline.jsx
- needed to add a webpack css loader to load react-datepicker css
- that `> div, > div > div, > div > div > div {` bit needed to be removed because it was fucking up react-datepicker layout. That's what happens when you style divs directly.