### PR TITLE
FAQ section

### DIFF
--- a/app/src/actions/faq.js
+++ b/app/src/actions/faq.js
@@ -1,0 +1,15 @@
+import { GET_FAQ_ENTRIES } from '../constants';
+import 'whatwg-fetch';
+
+export function getFAQEntries() {
+  return (dispatch) => {
+    fetch('/faq.json', {
+      method: 'GET'
+    }).then((response) => response.json()).then((data) => {
+      dispatch({
+        type: GET_FAQ_ENTRIES,
+        payload: data
+      });
+    });
+  };
+}

--- a/app/src/components/blog.jsx
+++ b/app/src/components/blog.jsx
@@ -3,7 +3,7 @@ import Header from '../containers/header';
 import Footer from './shared/footer';
 import { Link } from 'react-router';
 import listposts from '../../styles/components/c-list-posts.scss';
-import CoverBlog from './blog/cover_blog';
+import CoverPrimary from './shared/CoverPrimary';
 import PaginationBlog from './blog/pagination';
 import boxtriangle from '../../assets/icons/box_triangle.svg';
 
@@ -18,7 +18,7 @@ class Blog extends Component {
 
     if (this.props.recentPost) {
       articles = this.props.recentPost.posts.map((article) => (
-        <article>
+        <article key={article.id}>
           <Link to={`/blog/${article.slug}`}>
             <h2>{article.title}</h2>
           </Link>
@@ -46,7 +46,7 @@ class Blog extends Component {
 
     return (<div>
       <Header />
-      <CoverBlog />
+      <CoverPrimary title="Blog" subtitle="Latest news on Global Fishing Watch" />
       <section className={listposts['c-list-posts']}>
         {articles}
       </section>

--- a/app/src/components/blog_detail.jsx
+++ b/app/src/components/blog_detail.jsx
@@ -2,7 +2,8 @@ import React, { Component } from 'react';
 import listposts from '../../styles/components/c-list-posts.scss';
 import Header from '../containers/header';
 import Footer from './shared/footer';
-import CoverBlogDetail from './blog/cover_blog_detail';
+import { Link } from 'react-router';
+import CoverSecondary from './shared/CoverSecondary';
 
 class BlogDetail extends Component {
 
@@ -26,10 +27,11 @@ class BlogDetail extends Component {
     } else {
       article = (<div>Loading....</div>);
     }
+    let coverTitle = (<Link to={'/blog'}>Blog</Link>);
 
     return (<div>
       <Header />
-      <CoverBlogDetail title={this.props.post ? this.props.post.title : null} />
+      <CoverSecondary title={coverTitle} subtitle={this.props.post ? this.props.post.title : null} />
       <section className={listposts['c-list-posts']}>
         {article}
       </section>
@@ -40,7 +42,7 @@ class BlogDetail extends Component {
 
 BlogDetail.propTypes = {
   post: React.PropTypes.object,
-  params: React.PropTypes.array,
+  params: React.PropTypes.object,
   getPostBySlug: React.PropTypes.func
 };
 

--- a/app/src/components/faq.jsx
+++ b/app/src/components/faq.jsx
@@ -1,24 +1,63 @@
 import React, { Component } from 'react';
-import home from '../../styles/index.scss';
 import Header from '../containers/header';
 import Footer from './shared/footer';
+import CoverPrimary from './shared/CoverPrimary';
+import { Accordion, AccordionItem } from 'react-sanfona';
 
 class FAQ extends Component {
 
+  componentDidMount() {
+    this.props.getFAQEntries();
+  }
+
   render() {
+    let accordionEntries = [];
+    const faqEntries = this.props.faqEntries;
+    let faqPageContent;
+
+    if (faqEntries) {
+      for (let index = 0; index < faqEntries.length; index++) {
+        accordionEntries.push(
+          <AccordionItem
+            key={index}
+            title={faqEntries[index].questions}
+          >
+            <article >
+              <span
+                dangerouslySetInnerHTML={{
+                  __html: faqEntries[index].answer
+                }}
+              />
+            </article>
+          </AccordionItem>
+        );
+      }
+
+      faqPageContent = (
+        <Accordion allowMultiple>
+          {accordionEntries}
+        </Accordion>
+      );
+    }
+
     return (<div>
       <Header />
-      <section className={home.header_home}>
-        <div>
-          <h1>
-            Frequently Asked Questions
-          </h1>
-        </div>
+      <CoverPrimary
+        title="Frequently Asked Questions"
+        subtitle="Get answers to commonly asked questions about Global Fishing Watch and commercial fishing."
+      />
+      <section>
+        {faqPageContent}
       </section>
       <Footer />
     </div>);
   }
 
 }
+
+FAQ.propTypes = {
+  faqEntries: React.PropTypes.array,
+  getFAQEntries: React.PropTypes.func
+};
 
 export default FAQ;

--- a/app/src/components/shared/CoverPrimary.jsx
+++ b/app/src/components/shared/CoverPrimary.jsx
@@ -1,18 +1,18 @@
 import React, { Component } from 'react';
 import CoverPage from '../../../styles/components/c-cover-page.scss';
 
-class CoverBlog extends Component {
+class CoverPrimary extends Component {
 
   render() {
     return (<section className={CoverPage['c-cover-page']}>
       <div>
-        <h1 className={CoverPage.title_cover_blog}>
-          Blog
+        <h1 className={CoverPage['cover-main-title']}>
+          {this.props.title}
         </h1>
         <p>
-            Latest news on Global Fishing Watch
+          {this.props.subtitle}
         </p>
-        <div className={CoverPage.footer_header_blog}>
+        <div className={CoverPage.footer_header}>
           <div>Brought to you by:</div>
         </div>
       </div>
@@ -20,4 +20,9 @@ class CoverBlog extends Component {
   }
 }
 
-export default CoverBlog;
+CoverPrimary.propTypes = {
+  title: React.PropTypes.any,
+  subtitle: React.PropTypes.any
+};
+
+export default CoverPrimary;

--- a/app/src/components/shared/CoverSecondary.jsx
+++ b/app/src/components/shared/CoverSecondary.jsx
@@ -1,17 +1,16 @@
 import React, { Component } from 'react';
 import CoverPage from '../../../styles/components/c-cover-page.scss';
-import { Link } from 'react-router';
 
-class CoverBlogContainer extends Component {
+class CoverSecondary extends Component {
 
   render() {
     return (<section className={CoverPage['c-cover-page']}>
       <div>
-        <h1 className={CoverPage['title-cover-blog-detail']}>
-          <Link to={'/blog'}>Blog</Link>
-        </h1>
-        <p className={CoverPage['title-post-detail']}>
+        <h1 className={CoverPage['cover-sub-title']}>
           {this.props.title}
+        </h1>
+        <p className={CoverPage['cover-sub-subtitle']}>
+          {this.props.subtitle}
         </p>
         <div className={CoverPage.footer_header_blog}>
           <div>Brought to you by:</div>
@@ -21,8 +20,9 @@ class CoverBlogContainer extends Component {
   }
 }
 
-CoverBlogContainer.propTypes = {
-  title: React.PropTypes.string
+CoverSecondary.propTypes = {
+  title: React.PropTypes.any,
+  subtitle: React.PropTypes.any
 };
 
-export default CoverBlogContainer;
+export default CoverSecondary;

--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -16,6 +16,8 @@ export const TOKEN_SESSION = 'TOKEN_SESSION';
 export const GET_RECENT_POST = 'GET_RECENT_POST';
 export const GET_POST_BY_SLUG = 'GET_POST_BY_SLUG';
 
+export const GET_FAQ_ENTRIES = 'GET_FAQ_ENTRIES';
+
 // Filters actions
 export const UPDATE_FILTERS = 'UPDATE_FILTERS';
 

--- a/app/src/containers/faq.js
+++ b/app/src/containers/faq.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+import FAQ from '../components/faq';
+import { getFAQEntries } from '../actions/faq';
+
+const mapStateToProps = (state) => ({
+  faqEntries: state.faqEntries
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  getFAQEntries: () => dispatch(getFAQEntries())
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(FAQ);

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -8,6 +8,7 @@ import { syncHistoryWithStore, routerReducer, routerMiddleware } from 'react-rou
 import Routes from './routes';
 import '../styles/index.scss';
 import mapReducer from './reducers/map';
+import faqReducer from './reducers/faq';
 import userReducer from './reducers/user';
 import blogReducer from './reducers/blog';
 import filtersReducer from './reducers/filters';
@@ -27,6 +28,7 @@ const reducer = combineReducers({
   blog: blogReducer,
   filters: filtersReducer,
   appearance: appearanceReducer,
+  faqEntries: faqReducer,
   contactStatus: contactReducer
 });
 

--- a/app/src/reducers/faq.js
+++ b/app/src/reducers/faq.js
@@ -1,0 +1,11 @@
+const initialState = null;
+import { GET_FAQ_ENTRIES } from '../constants';
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case GET_FAQ_ENTRIES:
+      return action.payload;
+    default:
+      return state;
+  }
+}

--- a/app/src/reducers/map.js
+++ b/app/src/reducers/map.js
@@ -33,7 +33,7 @@ export default function (state = initialState, action) {
       const layers = state.layers.slice(0);
       for (let i = 0, length = layers.length; i < length; i++) {
         if (layers[i].title === action.payload.title) {
-          layers[i].visible = !action.payload.visible
+          layers[i].visible = !action.payload.visible;
           break;
         }
       }

--- a/app/src/routes.jsx
+++ b/app/src/routes.jsx
@@ -5,7 +5,7 @@ import MapContainer from './containers/map';
 import BlogContainer from './containers/blog';
 import BlogDetail from './containers/blog_detail';
 import ArticlesPublications from './components/articles_publications';
-import FAQ from './components/faq';
+import FAQContainer from './containers/faq';
 import Tutorials from './components/tutorials';
 import Definitions from './components/definitions';
 import TheProject from './components/the_project';
@@ -26,7 +26,7 @@ class Routes extends Component {
         <Route path="blog/:slug" component={BlogDetail} />
         <Route path="articles-publications" component={ArticlesPublications} />
 
-        <Route path="faq" component={FAQ} />
+        <Route path="faq" component={FAQContainer} />
         <Route path="tutorials" component={Tutorials} />
         <Route path="definitions" component={Definitions} />
 

--- a/app/styles/components/c-cover-page.scss
+++ b/app/styles/components/c-cover-page.scss
@@ -27,7 +27,7 @@
     }
   }
 
-  .title_cover_blog {
+  .cover-main-title {
 
     &::after {
       background-color: $color-6;
@@ -79,7 +79,7 @@
     }
   }
 
-  .footer_header_blog {
+  .footer_header {
     align-items: center;
     color: $color-4;
     display: flex;
@@ -89,7 +89,7 @@
     padding-right: 170px;
   }
 
-  .title-cover-blog-detail {
+  .cover-sub-title {
     font-family: $font-family-1;
     font-size: $font-size-medium;
     font-weight: $font-weight-bold;
@@ -112,7 +112,7 @@
     }
   }
 
-  .title-post-detail {
+  .cover-sub-subtitle {
     font-family: $font-family-1;
     font-size: $font-size-huge;
     font-weight: $font-weight-bold;

--- a/public/faq.json
+++ b/public/faq.json
@@ -1,0 +1,66 @@
+[
+  {
+    "question": "Can’t fishing vessels turn off their AIS?",
+    "answer": "<p>Yes. Soon, Global Fishing Watch can help detect when this appears to occur. When a vessel turns off its AIS, we can notice that and we will share that information publicly. We will also be able to flag activities such as ships disappearing or appearing suddenly, jumping 1,000 miles at once, or appearing to fish on land.</p>"
+  },
+  {
+    "question": "Can’t vessels just broadcast a false location in their AIS signals?",
+    "answer": "<p>We have seen vessel tracks that appear in impossible places such as the Himalayan Mountains or over Antarctica. We can’t say for sure whether the AIS has been tampered with or is faulty, but the errors have followed regular patterns—varying from a vessel’s true location by a constant amount, or flipping a coordinate from the Southern Hemisphere to the Northern Hemisphere, for example. Once we identify the patterns, we can often correct apparently false locations.</p>"
+  },
+  {
+    "question": "AIS requirements don’t cover all vessels, right?",
+    "answer": "<p>That’s right, but many of the largest vessels that catch most of the fish are covered. So this is a good start. In addition, many countries are creating AIS requirements within their waters, so we expect an increase in AIS use in the coming years. For example, as of May 31, 2014, all European Union flagged fishing vessels over 15 meters in length are required to use AIS in EU waters, and as of March 1, 2016, all U.S. flagged vessels over 65 feet in length are required to use AIS in U.S. waters. AIS was primarily designed as a safety mechanism to help avoid collisions at sea, so turning off AIS to avoid being tracked can put a vessel and its crew at risk of being hit by another ship.</p>"
+  },
+  {
+    "question": "Do “pirate” fishing vessels that engage in Illegal, Unreported and Unregulated (IUU) fishing even use AIS?",
+    "answer": "<p>Although not all of them do, we have seen vessels broadcasting AIS that appear to be fishing illegally. More importantly, by consistently using AIS, fishing vessel operators could (potentially) command a better price for their catch or gain access to markets that someday could be closed to vessels that don’t make themselves “visible” with AIS. As more vessels voluntarily use AIS to show they are operating legitimately, the size of the “dark fleet” will shrink, allowing authorities to focus their attention and resources more effectively on those vessels that continue to operate in the shadows.</p>"
+  },
+  {
+    "question": "How can I save or share my workspace?",
+    "answer": "<p>You may share your workspace by clicking on the share arrow at the bottom left of the map above the play button. This will bring up a unique url for your workspace, which you can copy and share with someone (the recipient will need to be registered for Global Fishing Watch in order to access your shared workspace, however).</p>"
+  },
+  {
+    "question": "How can I vary the amount of time I’m looking at?",
+    "answer": "<p>The Global Fishing Watch Time Slider at the bottom of the map determines the time period of the fishing effort heat map or vessel tracks you are viewing. There are several ways to manipulate the Time Slider, including the following:</p><ul><li>Click on the left or right edge of the Time Slider, hold and drag/extend the start or end time;</li><li>Click anywhere on the Time Slider and use your mouse scroll wheel or touchpad to see more (i.e. smaller) or fewer (i.e. larger) increments of time.</li><li>Click on the icon to the left of the Time Slider indicating more (i.e. smaller) or fewer (i.e. larger) increments of time.</li></ul>"
+  },
+  {
+    "question": "How do I search for a specific vessel?",
+    "answer": "<p>Click on the Info dropdown menu in the legend on the right edge of the map. Then click on the magnifying glass which brings up a search box where you can search by vessel MMSI number, IMO number, callsign, ship name or port name.</p>"
+  },
+  {
+    "question": "Is monitoring AIS signals an invasion of privacy?",
+    "answer": "<p>No. Monitoring vessel activity through satellite AIS is already a well-established practice in the shipping, insurance and commodities industries, and AIS data is already publicly available. AIS was designed to be an open, public communications tool. Vessels that use AIS are intentionally making themselves trackable to everyone around them. Global Fishing Watch shows apparent commercial resource extraction that takes place on the open ocean, not on private property. Our fisheries are a common resource, whether on the high seas that belong to everyone, or in the sovereign waters of individual nations.</p>"
+  },
+  {
+    "question": "Is the information I’m seeing in the map in real-time?",
+    "answer": "<p>The data you see on the Global Fishing Watch map is available in “near real-time,” typically within 72 hours.</p>"
+  },
+  {
+    "question": "What is the difference between MPA – No Take and MPA – Restricted Use?",
+    "answer": "<p>An MPA – No Take prohibits all fishing and other extraction measures within its boundaries. An MPA – Restricted Use allows fishing but imposes restrictions such as quotas, seasonal closures, or limits on certain types of fishing gear, methods or fishing sections (commercial vs. recreational).</p>"
+  },
+  {
+    "question": "What is the significance of the EEZs?",
+    "answer": "<p>An Exclusive Economic Zone (EEZ) is a sea zone extending 200 nautical miles from each nation’s coastline. Each country has special rights regarding exploration and use of resources within its EEZ. For example, if a country establishes that its fishing resources are being fully exploited by domestic fleets, it can exclude foreign vessels. A country can also allow foreign vessels to fish in its EEZ and can sell them fishing licenses, generating revenue.</p>"
+  },
+  {
+    "question": "Won’t this tip off the fishing industry to where all the fish are?",
+    "answer": "<p>Not really. Commercial fishing fleets are already using sophisticated technology like helicopters, tracking beacons, fish-finding sonar, and even fish forecasts based on satellite data to find and catch every fish they can. Global Fishing Watch shows where fishing activity has apparently occurred; it doesn’t predict where fish are likely to be in the future. The 72-hour time lag also limits the use of Global Fishing Watch as a “fish tracking” tool.</p>"
+  },
+  {
+    "question": "Why are there large circles in which there is no apparent fishing?",
+    "answer": "<p>The large circles without fishing are almost always EEZs around islands that heavily restrict or prohibit fishing (if you turn on the EEZ Layer in the Global Fishing Watch Map, you will see that they often line up with these blank areas). The circles could also be Marine Protected Areas that prohibit fishing (you can turn on the MPA layers to see if that’s the case).</p>"
+  },
+  {
+    "question": "Why is there fishing in an area marked as an MPA?",
+    "answer": "<p>Many Marine Protected Areas manage or restrict fishing within their borders but do not prohibit all fishing.</p>"
+  },
+  {
+    "question": "Can scientists and researchers get access to the raw data in Global Fishing Watch?",
+    "answer": "<p>We have several ways of collaborating with scientists and researchers, including allowing them access to the underlying AIS data. Please <a href=\"/contact-us\">contact us</a> if you are interested</p>"
+  },
+  {
+    "question": "How do I reach Global Fishing Watch with a press inquiry?",
+    "answer": "<p>Please fill out our <a href=\"/contact-us\">contact us</a> if you are interested or contact Dustin Cranor at (954) 348-1314 or via email at <a href=\"mailto:dcranor@oceana.org.\">dcranor@oceana.org</a>.</p>"
+  }
+]


### PR DESCRIPTION
I implemented the yet unstyled and undesigned FAQ section. I am reusing the react-safona component from the map for the accordion (the WF had one, there is still no design for this page). The current result is showing very little content, but it's a CSS issue, the data is in the DOM.

I extracted the header from the Blog/BlogDetails as reusable components.

The FAQ is being loaded from a JSON file in the public folder - loading from an API is not on the current roadmap, but this way making that change is as easy as it gets.

@hectoruch take a close look at CoverMain and CoverSub - these are basically the same files you created, but decoupled from the blog, so that they can be reused in other pages. Study this pattern and try to use it in the future.