### PR TITLE
fixed empty track at drag end

### DIFF
--- a/app/src/components/map.jsx
+++ b/app/src/components/map.jsx
@@ -365,7 +365,7 @@ class Map extends Component {
     if (!this.map) {
       return;
     }
-    if (this.state.trackLayer) {
+    if (this.state.trackLayer && this.props.map.track) {
       this.state.trackLayer.recalculatePosition();
 
       this.state.trackLayer.drawTile(


### PR DESCRIPTION
Really a simple fix but it's a simple issue: do not redraw track layer at drag end if no track information is available (no vessel has been clicked)