### PR TITLE
enforce css linter for edited/new files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "This repository will host the Global Fishing Watch client application developed by Vizzuality",
   "main": "server.js",
   "scripts": {
-    "test": "npm run lint-js || npm run lint-sass",
-    "lint-sass": "sass-lint -v -q 'app/**/*.scss'",
+    "test": "npm run lint-js && npm run lint-sass",
+    "lint-sass": "sass-lint -v -q `./scripts/get-scss-files-to-push.sh`",
     "lint-js": "eslint -c .eslintrc --ext .jsx,.js app",
     "build": "webpack --config ./config/webpack.config.js --progress --profile --colors",
     "postinstall": "npm run build"

--- a/scripts/get-scss-files-to-push.sh
+++ b/scripts/get-scss-files-to-push.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+regex="(.+\.scss)"
+scss_files=""
+
+for f in `git diff --stat --cached origin/master`
+do
+  if [[ $f =~ $regex ]]
+  then
+    scss_files+=$f
+    scss_files+=" "
+  fi
+done
+
+echo $scss_files

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,4 +1,1 @@
 npm test
-
-# allow push to carry on even with errors
-exit 0


### PR DESCRIPTION
I was pissed off by those 900+ sass errors, so this is a proposal: the `lint-sass` npm task will now only lint sass files that have been edited or added (compared to origin/master), but in exchange the pre-push hook will now exit whenever one of the two linters fail. 