### PR TITLE
implemented terms by url

### DIFF
--- a/app/src/components/Definitions.jsx
+++ b/app/src/components/Definitions.jsx
@@ -2,11 +2,10 @@ import React, { Component } from 'react';
 import CoverPrimary from './Shared/CoverPrimary';
 import Footer from './Shared/Footer';
 import Loader from './Shared/Loader';
-import ContentAccordion from './Shared/ContentAccordion';
+import ContentAccordion from '../containers/ContentAccordion';
 import AppStyles from '../../styles/application.scss';
 import StaticPageStyles from '../../styles/layout/l-static-page.scss';
 import definitionsBackgroundImage from '../../assets/images/definitions.jpg';
-
 
 class Definitions extends Component {
 
@@ -16,13 +15,17 @@ class Definitions extends Component {
   render() {
     let accordionContent = (<Loader />);
 
+    const activeItem = !!this.props.params ?
+      this.props.params.term : null;
+
     if (this.props.definitionEntries && this.props.definitionEntries.length > 0) {
       accordionContent = (<ContentAccordion
         entries={this.props.definitionEntries}
+        activeItem={activeItem}
       />);
     }
-
     return (<div>
+
       <CoverPrimary
         title="Definitions"
         subtitle="Review definitions of terms you will find across our site and as you explore the Map."
@@ -43,7 +46,8 @@ class Definitions extends Component {
 
 Definitions.propTypes = {
   definitionEntries: React.PropTypes.array,
-  getDefinitionEntries: React.PropTypes.func
+  getDefinitionEntries: React.PropTypes.func,
+  params: React.PropTypes.object
 };
 
 export default Definitions;

--- a/app/src/components/Home/CoverPage.jsx
+++ b/app/src/components/Home/CoverPage.jsx
@@ -4,6 +4,7 @@ import CoverPageStyle from '../../../styles/components/c-cover-page.scss';
 import baseStyle from '../../../styles/application.scss';
 import Slider from '../../lib/react-slick.min';
 import Header from '../../containers/Header';
+import { scrollTo } from '../../lib/Utils';
 import BoxTriangleStyle from '../../../styles/components/c-box-triangle.scss';
 import LogoLDF from '../../../assets/logos/ldf_logo.png';
 import sliderBackground1 from '../../../assets/images/background_1.jpg';
@@ -36,10 +37,10 @@ class CoverPage extends Component {
     this.setState({ currentSlider });
   }
 
-  gosection() {
-    $('html, body').animate({
-      scrollTop: $('#case_study').offset().top
-    }, 1000);
+  scrollPage() {
+    const el = document.getElementById('steps');
+    if (!el) return;
+    scrollTo(el);
   }
 
   render() {
@@ -66,7 +67,7 @@ class CoverPage extends Component {
     const sliderAttributions = [
       '© OCEANA / Juan Cuetos',
       null,
-      '© Steve De Neef ',
+      '© OCEANA / Eduardo Sorensen',
       '© OCEANA / Eduardo Sorensen',
       'Hoatzinexp/iStock/Thinkstock'
     ];
@@ -137,7 +138,7 @@ class CoverPage extends Component {
                 </div>
               </div>
             </Slider>
-            <div className={BoxTriangleStyle['c-box-triangle']} onClick={this.gosection}>
+            <div className={BoxTriangleStyle['c-box-triangle']} onClick={this.scrollPage}>
               <div className={BoxTriangleStyle['triangle-min']}></div>
             </div>
             <div className={CoverPageStyle['footer-header']}>

--- a/app/src/components/Home/CoverPage.jsx
+++ b/app/src/components/Home/CoverPage.jsx
@@ -67,10 +67,11 @@ class CoverPage extends Component {
     const sliderAttributions = [
       '© OCEANA / Juan Cuetos',
       null,
-      '© OCEANA / Eduardo Sorensen',
+      '© Steve De Neef',
       '© OCEANA / Eduardo Sorensen',
       'Hoatzinexp/iStock/Thinkstock'
     ];
+
     const sliderAttribution = sliderAttributions[this.state.currentSlider];
 
     return (

--- a/app/src/components/Home/Steps.jsx
+++ b/app/src/components/Home/Steps.jsx
@@ -10,7 +10,7 @@ class Steps extends Component {
   render() {
     return (
       <section className={baseStyle.wrap}>
-        <div className={StepsStyle['c-steps']}>
+        <div className={StepsStyle['c-steps']} id="steps">
           <div className={StepsStyle.intro}>
             <p>Global Fishing Watch uses public broadcast data from the Automatic Identification System (AIS),
             collected by satellite and terrestrial receivers, to show the movement of vessels over time.</p>

--- a/app/src/components/Shared/ContentAccordion.jsx
+++ b/app/src/components/Shared/ContentAccordion.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { AccordionItem } from 'react-sanfona';
 import AccordionGF from '../../lib/AccordionGF';
-
 import AccordionStyles from '../../../styles/components/shared/c-content-accordion.scss';
 
 class ContentAccordion extends Component {

--- a/app/src/components/Shared/ContentAccordion.jsx
+++ b/app/src/components/Shared/ContentAccordion.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Accordion, AccordionItem } from 'react-sanfona';
+import { AccordionItem } from 'react-sanfona';
+import AccordionGF from '../../lib/AccordionGF';
 
 import AccordionStyles from '../../../styles/components/shared/c-content-accordion.scss';
 
@@ -10,8 +11,6 @@ class ContentAccordion extends Component {
     this.state = {
       isOpen: false
     };
-
-    this.toggleItemBound = this.toggleItem.bind(this);
   }
 
   getAccordionItems() {
@@ -40,29 +39,60 @@ class ContentAccordion extends Component {
     return accordionItems;
   }
 
+  // returns position in entries array if found
+  getIndexActiveItem() {
+    const term = this.props.activeItem;
+    const entries = this.props.entries;
+    let index = -1;
+
+    if (!term) return index;
+
+    index = entries.findIndex((entry) =>
+      entry.slug === term.toLowerCase()
+    );
+
+    return [index];
+  }
+
   // changes arrow's direction when open and close
   // we are not using it right now because we are not
   // implementing the arrows. We'll do in a nerby future.
-  toggleItem() {
-    this.setState({ isOpen: !this.state.isOpen });
+  toggleItem(e) {
+    const entries = this.props.entries;
+    const indexEntry = e.activeItems[0];
+
+    const titleEntry = entries[indexEntry] ?
+      entries[indexEntry].slug : null;
+
+    if (!titleEntry) return;
+
+    // updates url with new entry title selected
+    this.props.push(titleEntry);
+
+    // not working right now
+    // this.setState({ isOpen: !this.state.isOpen });
   }
 
   render() {
     return (
-      <Accordion
-        allowMultiple={false}
-        activeItems={-1}
-        className={AccordionStyles['c-content-accordion']}
-        onChange={this.toggleItemBound}
-      >
+      <div>
+        <AccordionGF
+          allowMultiple={false}
+          activeItems={this.getIndexActiveItem()}
+          className={AccordionStyles['c-content-accordion']}
+          onChange={(e) => this.toggleItem(e)}
+        >
         {this.getAccordionItems()}
-      </Accordion>
+        </AccordionGF>
+      </div>
     );
   }
 }
 
 ContentAccordion.propTypes = {
-  entries: React.PropTypes.array
+  activeItem: React.PropTypes.string,
+  entries: React.PropTypes.array,
+  push: React.PropTypes.func
 };
 
 export default ContentAccordion;

--- a/app/src/components/Shared/CoverPrimary.jsx
+++ b/app/src/components/Shared/CoverPrimary.jsx
@@ -43,7 +43,10 @@ CoverPrimary.propTypes = {
   title: React.PropTypes.any,
   subtitle: React.PropTypes.any,
   attribution: React.PropTypes.any,
-  backgroundImage: React.PropTypes.object
+  backgroundImage: React.PropTypes.oneOfType([
+    React.PropTypes.object,
+    React.PropTypes.string
+  ])
 };
 
 export default CoverPrimary;

--- a/app/src/containers/ContentAccordion.js
+++ b/app/src/containers/ContentAccordion.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import ContentAccordion from '../components/Shared/ContentAccordion';
+import { push } from 'react-router-redux';
+
+
+const mapDispatchToProps = (dispatch) => ({
+  push: (term) => dispatch(push(`/definitions/${term}`))
+});
+
+export default connect(null, mapDispatchToProps)(ContentAccordion);

--- a/app/src/lib/AccordionGF.jsx
+++ b/app/src/lib/AccordionGF.jsx
@@ -1,0 +1,11 @@
+import { Accordion } from 'react-sanfona';
+
+class AccordionGF extends Accordion {
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.activeItems !== this.state.activeItems) {
+      this.setState({ activeItems: nextProps.activeItems });
+    }
+  }
+}
+
+export default AccordionGF;

--- a/app/src/lib/AccordionGF.jsx
+++ b/app/src/lib/AccordionGF.jsx
@@ -1,10 +1,25 @@
 import { Accordion } from 'react-sanfona';
+import { scrollTo } from './Utils';
 
 class AccordionGF extends Accordion {
   componentWillReceiveProps(nextProps) {
     if (nextProps.activeItems !== this.state.activeItems) {
       this.setState({ activeItems: nextProps.activeItems });
     }
+  }
+
+  componentDidMount() {
+    const el = document.getElementsByClassName('react-sanfona-item-expanded');
+    if(!el.length > 0) return;
+    scrollTo(el);
+  }
+  componentDidUpdate() {
+    const el = document.getElementsByClassName('react-sanfona-item-expanded');
+    if(!el.length > 0) return;
+
+    // adds timeout to give time to the accordion to close last item-title
+    // and recalculate height properly
+    setTimeout(() => scrollTo(el), 300);
   }
 }
 

--- a/app/src/lib/Utils.jsx
+++ b/app/src/lib/Utils.jsx
@@ -1,0 +1,7 @@
+const scrollTo = function(el) {
+  $('html, body').animate({
+    scrollTop: $(el).offset().top
+  }, 500);
+}
+
+export { scrollTo };

--- a/app/src/routes.jsx
+++ b/app/src/routes.jsx
@@ -26,7 +26,9 @@ class Routes extends Component {
 
         <Route path="faq" component={FAQContainer} />
         <Route path="tutorials" component={Tutorials} />
-        <Route path="definitions" component={Definitions} />
+        <Route path="definitions" component={Definitions}>
+          <Route path=":term" component={Definitions} />
+        </Route>
 
         <Route path="the-project" component={TheProject} />
         <Route path="partners" component={Partners} />

--- a/public/definitions.json
+++ b/public/definitions.json
@@ -1,58 +1,72 @@
 [
   {
     "title": "AIS",
+    "slug": "ais",
     "content": "<p>“AIS” stands for the Automatic Identification System. It is a maritime navigation safety communications system standardized by the International Telecommunication Union (ITU) and adopted by the International Maritime Organization (IMO) that provides vessel information, including the vessel’s identity, type, position, course, speed, navigational status and other safety-related information automatically to appropriately equipped shore stations, other ships and aircraft; automatically receives such information from similarly fitted ships; monitors and tracks ships; and exchanges data with shore-based facilities.</p>"
   },
   {
     "title": "BATHYMETRY",
+    "slug": "bathymetry",
     "content": "<p>The depth and topography of the seafloor.</p>"
   },
   {
     "title": "CALLSIGN",
+    "slug": "callsign",
     "content": "<p>The unique identification of a Vessel’s radio transmissions assigned to it by its national licensing authority.</p>"
   },
   {
     "title": "CLASS",
+    "slug": "class",
     "content": "<p>The type of AIS transponder a vessel uses – Class A transponders are the most expensive and transmit at 12.5 watts. There are two types of Class B transponders – Class B/SO, which transmits at 5 watts (2 watts @ low power) and Class B/CS receiver, which transmits at 2 watts.</p>"
   },
   {
     "title": "EEZ",
+    "slug": "eez",
     "content": "<p>“EEZ” stands for Exclusive Economic Zone and is a state’s sovereign waters, which extend 200 nautical miles from the coast.</p>"
   },
   {
     "title": "FISHING EFFORT",
+    "slug": "fishing-effort",
     "content": "<p>Global Fishing Watch uses data about a vessel’s identity, type, location, speed, direction and more that is broadcast using the Automatic Identification System (AIS) and collected via satellites and terrestrial receivers. AIS was developed for safety/collision-avoidance. Global Fishing Watch analyzes AIS data collected from vessels that our research has identified as known or possible commercial fishing vessels, and applies a fishing detection algorithm to determine “apparent fishing effort” based on changes in vessel speed and direction. The algorithm classifies each AIS broadcast data point for these vessels as either apparently fishing or not fishing and shows the former on the Global Fishing Watch fishing effort heat map. AIS data as broadcast may vary in completeness, accuracy and quality. Also, data collection by satellite or terrestrial receivers may introduce errors through missing or inaccurate data. Global Fishing Watch’s fishing detection algorithm is a best effort mathematically to identify “apparent fishing effort.” As a result, it is possible that some fishing effort is not identified as such by Global Fishing Watch; conversely, Global Fishing Watch may show apparent fishing effort where fishing is not actually taking place. For these reasons, Global Fishing Watch qualifies designations of vessel fishing effort, including synonyms of the term “fishing effort,” such as “fishing” or “fishing activity,” as “apparent,” rather than certain. Any/all Global Fishing Watch information about “apparent fishing effort” should be considered an estimate and must be relied upon solely at your own risk. Global Fishing Watch is taking steps to make sure fishing effort designations are as accurate as possible. Global Fishing Watch fishing detection algorithms are developed and tested using actual fishing event data collected by observers, combined with expert analysis of vessel movement data resulting in the manual classification of thousands of known fishing events. Global Fishing Watch also collaborates extensively with academic researchers through our research partner program to share fishing effort classification data and automated classification techniques.</p>"
   },
   {
     "title": "FLAG",
+    "slug": "flag",
     "content": "<p>The state a vessel is registered or licensed under.</p>"
   },
   {
     "title": "HIGH SEAS POCKETS",
+    "slug": "high-seas-pockets",
     "content": "<p>The High Seas are any area of the ocean beyond Exclusive Economic Zones (EEZ). High Seas pockets are areas totally enclosed by EEZs. These pockets can be hard to distinguish from the multiple EEZ jurisdictions that surround them, thus, we have a layer that highlights them.</p>"
   },
   {
     "title": "IMO",
+    "slug": "imo",
     "content": "<p>IMO stands for International Maritime Organization. It is the United Nations specialized agency with responsibility for the safety and security of shipping and the prevention of marine pollution by ships.</p></p>The IMO number is a unique vessel identification number assigned by the IMO to sea-going ships under the International Convention for the Safety of Life at Sea (SOLAS). The IMO also  requires Automatic Identification System (AIS) to be used by all cargo ships of 500 gross tonnage and upwards, all ships of 300 gross tonnage and upwards engaged on international voyages, and all passenger ships.</p>"
   },
   {
     "title": "MMSI",
+    "slug": "mmsi",
     "content": "<p>MMSI stands for Maritime Mobile Service Identity. It is a unique nine-digit number assigned to every Automatic Identification System (AIS) transmission made by a vessel.</p>"
   },
   {
     "title": "MPA – NO TAKE",
+    "slug": "mpa-no-take",
     "content": "<p>MPA stands for Marine Protected Area. A No-Take Marine Protected Area is an area of ocean in which the extraction or significant destruction of natural cultural resources, including fish, is prohibited.</p>"
   },
   {
     "title": "MPA – RESTRICTED USE",
+    "slug": "map-restricted-use",
     "content": "<p>MPA stands for Marine Protected Area. A Restricted Use Marine Protected Area, is an area of ocean in which the extraction or significant destruction of natural cultural resources, including fish, is restricted by prohibition of fishing in certain areas or during certain times of year.</p>"
   },
   {
     "title": "NAME",
+    "slug": "name",
     "content": "<p>A vessel’s name. Vessel names can be changed without notice, and are often used by multiple vessels, so the name alone is not a robust form of identity.</p>"
   },
   {
     "title": "RFMO",
+    "slug": "rfmo",
     "content": "<p>RFMO stands for Regional Fishery Management Organization. These Organizations are international organizations formed by countries with a shared interest in managing or conserving an area’s fish stock. Some RFMOs manage all the fish stocks found in a specific area, while others focus on particular highly migratory species, notably tuna, throughout vast geographical areas. The RFMOs Layer on the Global Fishing Watch map currently includes the five tuna RFMOs.</p>"
   }
 ]


### PR DESCRIPTION
- Created `ContentAccordion ` container to allow router management (`push` function).
- When the user clicks on a item, the url will be updated with the new slug entry.
- Back and forward navigation works smoothly.
- Added `slug` property in JSON file: this way we avoid use regexp and other problems generated because inconsistent format. 

The default library didn't include a `componentWillReceiveProps ` function that allows us update the component with new props, that's why we have to create our "own" accordion and overwritting the function to allow us update the component (that allows the accordion being updated if you want to go back to see your las entry).

Probably you will have doubts about this, talk to me if need!

Kudos to Ra for helping me with this!

