### PR TITLE
Forces the app to scroll to top when routing

### DIFF
--- a/app/src/routes.jsx
+++ b/app/src/routes.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { useScroll } from 'react-router-scroll';
 import AppContainer from './containers/App';
 import HomeContainer from './components/Home';
 import AuthMapContainer from './containers/AuthMap';
@@ -11,35 +12,113 @@ import TheProject from './components/TheProject';
 import Partners from './components/Partners';
 import TermsOfUse from './components/TermsOfUse';
 import PrivacyPolicy from './components/PrivacyPolicy';
-import { Router, Route, IndexRoute } from 'react-router';
+import { Router, Route, IndexRoute, applyRouterMiddleware } from 'react-router';
 import ContactUsContainer from './containers/ContactUs';
+
+/**
+ * Return whether the page should be scrolled to top when
+ * routing from one to another
+ *
+ * @param {Object} prevRouterProps
+ * @param {Object} { location }
+ * @returns {Boolean}
+ */
+function shouldUpdateScroll(prevRouterProps, { location }) {
+  /**
+   * Return whether the two pages match the regex and have the same matching
+   * regex parameters
+   * @param  {regex}  regex
+   * @return {Boolean}
+   */
+  function isSamePage(regex) {
+    const pathname = (prevRouterProps && prevRouterProps.location.pathname) || '';
+    const nextPathname = location.pathname;
+
+    /* We first check if the pages are concerned by the regex. If not, the route
+     * isn't matching */
+    const isPathnameConcerned = regex.test(pathname);
+    const isNextPathnameConcerned = regex.test(nextPathname);
+
+    if (!isPathnameConcerned || !isNextPathnameConcerned) {
+      return false;
+    }
+
+    /* We then get the matching regex params and return false if there isn't
+     * any */
+    const routeParams = pathname.match(regex);
+    const nextRouteParams = nextPathname.match(regex);
+
+    if (!routeParams || !nextRouteParams) {
+      return false;
+    }
+
+    /* We remove the first element of the arrays as it is the whole matched
+     * string (i.e. the route) */
+    if (routeParams.length) {
+      routeParams.splice(0, 1);
+    }
+    if (nextRouteParams.length) {
+      nextRouteParams.splice(0, 1);
+    }
+
+    const paramsCount = Math.min(routeParams.length, nextRouteParams.length);
+
+    let doesParamsMatch = true;
+    for (let i = 0, j = paramsCount; i < j; i++) {
+      if (routeParams[i] !== nextRouteParams[i]) {
+        doesParamsMatch = false;
+        break;
+      }
+    }
+
+    return doesParamsMatch;
+  }
+
+  /* Here we define all the routes for which we don't want to scroll to top if
+   * both the old path and the new one match (i.e. if the global regex and the
+   * regex params match the two paths) */
+  const regexes = [];
+
+  for (let i = 0, j = regexes.length; i < j; i++) {
+    if (isSamePage(regexes[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 class Routes extends Component {
   render() {
-    return (<Router history={this.props.history}>
-      <Route path="/" component={AppContainer}>
-        <IndexRoute component={HomeContainer} />
+    return (
+      <Router
+        history={this.props.history}
+        render={applyRouterMiddleware(useScroll(shouldUpdateScroll))}
+      >
+        <Route path="/" component={AppContainer}>
+          <IndexRoute component={HomeContainer} />
 
-        <Route path="map" component={AuthMapContainer} />
+          <Route path="map" component={AuthMapContainer} />
 
-        <Route path="articles-publications" component={ArticlesPublications} />
+          <Route path="articles-publications" component={ArticlesPublications} />
 
-        <Route path="faq" component={FAQContainer} />
-        <Route path="tutorials" component={Tutorials} />
-        <Route path="definitions" component={Definitions}>
-          <Route path=":term" component={Definitions} />
+          <Route path="faq" component={FAQContainer} />
+          <Route path="tutorials" component={Tutorials} />
+          <Route path="definitions" component={Definitions}>
+            <Route path=":term" component={Definitions} />
+          </Route>
+
+          <Route path="the-project" component={TheProject} />
+          <Route path="partners" component={Partners} />
+          <Route path="contact-us" component={ContactUsContainer} />
+
+          <Route path="terms-of-use" component={TermsOfUse} />
+          <Route path="privacy-policy" component={PrivacyPolicy} />
+
+          <Route path="orbcomm" component={Orbcomm} />
         </Route>
-
-        <Route path="the-project" component={TheProject} />
-        <Route path="partners" component={Partners} />
-        <Route path="contact-us" component={ContactUsContainer} />
-
-        <Route path="terms-of-use" component={TermsOfUse} />
-        <Route path="privacy-policy" component={PrivacyPolicy} />
-
-        <Route path="orbcomm" component={Orbcomm} />
-      </Route>
-    </Router>);
+      </Router>
+    );
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -60,20 +60,18 @@
     "react-redux": "^4.4.5",
     "react-router": "^2.4.1",
     "react-router-redux": "^4.0.4",
+    "react-router-scroll": "^0.3.2",
     "react-sanfona": "0.0.14",
     "react-slick": "^0.12.2",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
+    "resolve-url-loader": "1.6.0",
     "sass-loader": "^3.2.0",
     "slick-carousel": "^1.6.0",
     "style-loader": "^0.13.1",
     "svg-react-loader": "^0.3.7",
     "webpack": "^1.13.0",
-    "whatwg-fetch": "^1.0.0",
-    "svg-react-loader": "^0.3.7",
-    "css-loader": "^0.23.1",
-    "style-loader": "^0.13.1",
-    "resolve-url-loader": "1.6.0"
+    "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "^3.2.0",


### PR DESCRIPTION
This PR forces the app to scroll to top when routing so the user won't stay at the bottom of the page when its content changes. The solution uses a new library called [react-router-scroll](https://github.com/taion/react-router-scroll) which permits a per-route-transition decision whether the page should be scrolled.

The function `shouldUpdateScroll` which is the one deciding of the scroll, forces it to happen unless the developer specifies a list of regexes (inside the array `regexes`) for which, if the previous page and the next one match one of them, then the page won't be scrolled. An example of how this is handle can be found in PREP [here](https://github.com/resource-watch/prep-app/blob/develop/app/scripts/routes.jsx#L76-L79).