### PR TITLE
Workspace id is now part of the map's route

### DIFF
--- a/app/src/components/AuthMap.jsx
+++ b/app/src/components/AuthMap.jsx
@@ -11,8 +11,8 @@ class AuthMap extends Component {
   }
 
   render() {
-    return (EMBED_MAP_URL) ? <MapIFrameContainer location={this.props.location} /> :
-      <MapContainer location={this.props.location} />;
+    return (EMBED_MAP_URL) ? <MapIFrameContainer workspaceId={this.props.params.workspace} /> :
+      <MapContainer workspaceId={this.props.params.workspace} />;
   }
 }
 
@@ -32,7 +32,11 @@ AuthMap.propTypes = {
   /**
    * Method to redirect the user to SalesForce to login and get the token
    */
-  login: React.PropTypes.func
+  login: React.PropTypes.func,
+  /**
+   * Params from the route
+   */
+  params: React.PropTypes.object
 };
 
 export default AuthMap;

--- a/app/src/containers/Map.js
+++ b/app/src/containers/Map.js
@@ -22,41 +22,38 @@ const mapStateToProps = (state) => ({
   shareModal: state.map.shareModal
 });
 
-const mapDispatchToProps = (dispatch, { location }) => {
-  const queryParams = location.query;
-  return {
-    getWorkspace: () => {
-      dispatch(getWorkspace(queryParams.workspace));
-    },
-    toggleLayerVisibility: (layer) => {
-      dispatch(toggleLayerVisibility(layer));
-    },
-    updateFilters: (filters) => {
-      dispatch(updateFilters(filters));
-    },
-    setCurrentVessel: (vesselInfo) => {
-      dispatch({
-        type: RESET_VESSEL_DETAILS,
-        payload: vesselInfo
-      });
-      if (vesselInfo) {
-        dispatch(setCurrentVessel(vesselInfo));
-        dispatch(getVesselTrack(vesselInfo.seriesgroup, vesselInfo.series));
-      }
-    },
-    setZoom: zoom => dispatch(setZoom(zoom)),
-    setCenter: center => dispatch(setCenter(center)),
-
-    openShareModal: () => {
-      dispatch(openShareModal(true));
-      dispatch(saveWorkspace(setShareModalError));
-    },
-    closeShareModal: () => {
-      dispatch(openShareModal(false));
-      dispatch(deleteWorkspace());
-      dispatch(setShareModalError(null));
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  getWorkspace: () => {
+    dispatch(getWorkspace(ownProps.workspaceId));
+  },
+  toggleLayerVisibility: (layer) => {
+    dispatch(toggleLayerVisibility(layer));
+  },
+  updateFilters: (filters) => {
+    dispatch(updateFilters(filters));
+  },
+  setCurrentVessel: (vesselInfo) => {
+    dispatch({
+      type: RESET_VESSEL_DETAILS,
+      payload: vesselInfo
+    });
+    if (vesselInfo) {
+      dispatch(setCurrentVessel(vesselInfo));
+      dispatch(getVesselTrack(vesselInfo.seriesgroup, vesselInfo.series));
     }
-  };
-};
+  },
+  setZoom: zoom => dispatch(setZoom(zoom)),
+  setCenter: center => dispatch(setCenter(center)),
+
+  openShareModal: () => {
+    dispatch(openShareModal(true));
+    dispatch(saveWorkspace(setShareModalError));
+  },
+  closeShareModal: () => {
+    dispatch(openShareModal(false));
+    dispatch(deleteWorkspace());
+    dispatch(setShareModalError(null));
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(Map);

--- a/app/src/containers/MapIFrame.js
+++ b/app/src/containers/MapIFrame.js
@@ -1,9 +1,8 @@
 import { connect } from 'react-redux';
 import MapIFrame from '../components/MapIFrame';
 
-const mapStateToProps = (state, { location }) => ({
-  token: state.user.token,
-  workspaceId: location.query && location.query.workspace ? location.query.workspace : null
+const mapStateToProps = (state) => ({
+  token: state.user.token
 });
 
 const mapDispatchToProps = () => ({});

--- a/app/src/routes.jsx
+++ b/app/src/routes.jsx
@@ -98,7 +98,7 @@ class Routes extends Component {
         <Route path="/" component={AppContainer}>
           <IndexRoute component={HomeContainer} />
 
-          <Route path="map" component={AuthMapContainer} />
+          <Route path="map(/workspace/:workspace)" component={AuthMapContainer} />
 
           <Route path="articles-publications" component={ArticlesPublications} />
 


### PR DESCRIPTION
This PR implements Pivotal's task [#128974855](https://www.pivotaltracker.com/story/show/128974855). We want the map's URL with workspace specified to go from
`http://gfw.org/map?workspace=123`
to
`http://gfw.org/map/workspace/123`.