### PR TITLE
implemented basic polyfills

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist/**/*
 app/src/lib
+app/src/util/assignPolyfill.js

--- a/app/src/components/Shared/Header.jsx
+++ b/app/src/components/Shared/Header.jsx
@@ -87,7 +87,7 @@ class Header extends Component {
                 <li className={styles.dropdown}>
                   <a
                     className={
-                      location.pathname.startsWith('/articles-publications')
+                      location.pathname.indexOf('/articles-publications') !== -1
                         ? styles['-active'] : null
                     }
                   >

--- a/app/src/util/assignPolyfill.js
+++ b/app/src/util/assignPolyfill.js
@@ -1,0 +1,22 @@
+
+if (typeof Object.assign !== 'function') {
+  Object.assign = function assign(target) {
+
+    if (target == null) {
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    target = Object(target);
+    for (var index = 1; index < arguments.length; index++) {
+      var source = arguments[index];
+      if (source != null) {
+        for (var key in source) {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key];
+          }
+        }
+      }
+    }
+    return target;
+  };
+}

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -16,7 +16,7 @@ const webpackConfig = {
 
   entry: [
     'whatwg-fetch',
-    'babel-polyfill',
+    path.join(rootPath, 'app/src/util/assignPolyfill.js'),
     path.join(rootPath, 'app/src/index.jsx')
   ],
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -16,6 +16,7 @@ const webpackConfig = {
 
   entry: [
     'whatwg-fetch',
+    'babel-polyfill',
     path.join(rootPath, 'app/src/index.jsx')
   ],
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
+    "babel-polyfill": "^6.13.0",
     "eslint": "^3.2.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
-    "babel-polyfill": "^6.13.0",
     "eslint": "^3.2.0",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.12.0",


### PR DESCRIPTION
This polyfill brings this:

`This means you can use new built-ins like Promise or WeakMap, static methods like Array.from or Object.assign, instance methods like Array.includes, and generator functions (provided you use the regenerator plugin). The polyfill adds to the global scope as well as native prototypes like String in order to do this.`

from [https://babeljs.io/docs/usage/polyfill/](https://babeljs.io/docs/usage/polyfill/)