### PR TITLE
Improves the responsiveness of the accordion and the position of its rhombus

### DIFF
--- a/app/src/components/Shared/Accordion.jsx
+++ b/app/src/components/Shared/Accordion.jsx
@@ -26,7 +26,7 @@ class Accordion extends Component {
     if (this.props.entries && this.props.entries.length > 0) {
       entries = this.props.entries.map((entry, index) => {
         let classNames = AccordionStyles['item-content'];
-        const rhombusDirection = (index === this.props.currentAccordionIndex) ? '-down' : '-right';
+        const rhombusDirection = (index === this.props.currentAccordionIndex) ? '-down' : '-left';
 
         if (index === this.props.currentAccordionIndex) {
           classNames += ` ${AccordionStyles['-opened']}`;

--- a/app/styles/components/shared/c-content-accordion.scss
+++ b/app/styles/components/shared/c-content-accordion.scss
@@ -7,7 +7,8 @@
   }
 
   > .accordion-item {
-    padding: 25px 0 30px;
+    border-bottom: 2px solid $color-10;
+    padding: 25px 0;
     position: relative;
 
     &:first-child {
@@ -15,21 +16,8 @@
     }
 
     &:last-child {
+      border-bottom: 0;
       padding-bottom: 0;
-
-      &::after {
-        content: none;
-      }
-    }
-
-    &::after {
-      background-color: $color-10;
-      bottom: 0;
-      content: '';
-      height: 2px;
-      position: absolute;
-      top: auto;
-      width: 100%;
     }
 
     @media #{$mq-tablet} {
@@ -42,17 +30,19 @@
     cursor: pointer;
     font-size: 19px;
     font-weight: $font-weight-bold;
-    margin-bottom: 20px;
+    padding-right: 50px;
     position: relative;
     width: 100%;
   }
 
   > .accordion-item .item-rhombus {
-    float: right;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   > .accordion-item .item-content {
-    margin-top: 20px;
     max-height: 0;
     overflow: hidden;
     transition: max-height 0s;
@@ -64,8 +54,8 @@
   }
 
   > .accordion-item .-opened {
+    margin-top: 20px;
     max-height: 3000px;
     transition: max-height 1.5s;
-
   }
 }


### PR DESCRIPTION
This PR brings small changes to the accordion following Héctor's comments:
* Change the direction of the rhombus to follow the design
* Add a padding to the right of the titles so the rhombus doesn't overlap them
* Vertically center the rhombus

[Pivotal task](https://www.pivotaltracker.com/story/show/129783887)