### PR TITLE
Fixes the position of the arrow within the rhombus

### DIFF
--- a/app/src/components/Shared/Rhombus.jsx
+++ b/app/src/components/Shared/Rhombus.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import '../../../styles/components/shared/c-rhombus.scss';
 
 // This component is used to replace the rhombus element around the website.
@@ -8,12 +9,26 @@ class Rhombus extends Component {
   render() {
     return (
       <div
-        className={`c-rhombus ${this.props.direction} ${this.props.color}`}
+        className={classnames({
+          'c-rhombus': true,
+          [this.props.direction]: !!this.props.direction,
+          [this.props.color]: !!this.props.color
+        })}
         onClick={this.props.onClick}
       >
-        <span className={`rhombus ${this.props.color}`}></span>
+        <span
+          className={classnames({
+            rhombus: true,
+            [this.props.color]: !!this.props.color
+          })}
+        ></span>
         {this.props.children &&
-          <span className={`text ${this.props.color}`}>
+          <span
+            className={classnames({
+              text: true,
+              [this.props.color]: !!this.props.color
+            })}
+          >
             {this.props.children}
           </span>}
       </div>

--- a/app/styles/components/shared/c-rhombus.scss
+++ b/app/styles/components/shared/c-rhombus.scss
@@ -8,10 +8,10 @@
   > .rhombus {
     border: 2px solid $color-14;
     display: inline-block;
-    height: 17px;
+    height: 18px;
     position: relative;
-    transform: rotate(45deg);
-    width: 17px;
+    transform: rotate(135deg); // By default oriented to the top
+    width: 18px;
 
     &::after {
       border: 2px solid $color-14;
@@ -23,7 +23,7 @@
       left: 50%;
       position: absolute;
       top: 50%;
-
+      transform: translate(-2px, -4px); // Fixed to avoid subpixel issues
       width: 6px;
     }
 
@@ -60,21 +60,15 @@
     }
   }
 
-  &.-left > .rhombus {
-    &::after {
-      transform: translate(calc(-50% + 2px), calc(-50% - 1px));
-    }
+  &.-down > .rhombus {
+    transform: rotate(-45deg);
   }
 
   &.-right > .rhombus {
-    &::after {
-      transform: translate(calc(-50% - 2px), calc(-50%)) rotate(180deg);
-    }
+    transform: rotate(-135deg);
   }
 
-  &.-down > .rhombus {
-    &::after {
-      transform: translate(calc(-50% - 2px), calc(-50% - 2px)) rotate(-90deg);
-    }
+  &.-left > .rhombus {
+    transform: rotate(45deg);
   }
 }


### PR DESCRIPTION
This PR mainly fixes an issue where the Rhombus' arrow wouldn't be centered. Before, it would be displayed like that:
<img width="50" alt="screen shot 2016-09-05 at 13 57 02" src="https://cloud.githubusercontent.com/assets/6073968/18250708/20d9cc6c-7385-11e6-8832-4f8c3de80038.png">

Additionally, it prevents the element to get `null`classes and simplifies the CSS.

[Pivotal task](https://www.pivotaltracker.com/story/show/129787117)