### PR TITLE
Removes the horizontal scroll from the homepage

### DIFF
--- a/app/styles/components/c-info-map-content.scss
+++ b/app/styles/components/c-info-map-content.scss
@@ -1,8 +1,8 @@
 @import '../settings';
 
 .c-info-map-content {
+  max-width: 360px;
   position: relative;
-  width: 360px;
   z-index: 1;
 
   h2 {


### PR DESCRIPTION
This PR fixes an issue where the homepage could be horizontally scrolled on mobile devices (at least iOS) because the width of a section was fixed to dimension larger than the permitted one.

[Pivotal Task](https://www.pivotaltracker.com/story/show/129919141)