### PR TITLE
Debounces the resize callback of CoverPage

### DIFF
--- a/app/src/components/Home/CoverPage.jsx
+++ b/app/src/components/Home/CoverPage.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import $ from 'jquery';
+import _ from 'lodash';
 import classnames from 'classnames';
 import CoverPageStyle from '../../../styles/components/c-cover-page.scss';
 import baseStyle from '../../../styles/application.scss';
@@ -25,6 +26,8 @@ class CoverPage extends Component {
       speedPlaySlider: 10000,
       windowWidth: window.innerWidth
     };
+
+    this.handleResize = _.debounce(this.handleResize.bind(this), 50);
   }
 
   componentDidMount() {
@@ -38,7 +41,7 @@ class CoverPage extends Component {
       }
       this.setState({ autoPlaySlider: false });
     });
-    window.addEventListener('resize', () => this.handleResize());
+    window.addEventListener('resize', this.handleResize);
   }
 
   onSliderChange(currentSlider) {


### PR DESCRIPTION
This PR makes the homepage great again. The issue was that the homepage would freeze when resizing the browser's window. The reason is that the resize callback would be executed on each event instead of being debounced.

@hectoruch When you resize the window, the resize event is sent at an incredible frequency, we thus need to debounce. If we don't do it, the state of CoverPage will keep on being updated and, if I'm not wrong, React will wait for it to "stabilize" before rendering the component again. Also, because the state updates are stored in a queue, we just fill the memory too fast, without emptying it. That's why the page was really slow.

[Pivotal Task](https://www.pivotaltracker.com/story/show/129830859)