### PR TITLE
Map perfs

### DIFF
--- a/app/src/components/Layers/CanvasLayer.jsx
+++ b/app/src/components/Layers/CanvasLayer.jsx
@@ -228,26 +228,13 @@ class CanvasLayer {
    * @param playbackData
    * @param drawTrail
    */
-  drawTileFromPlaybackData(canvas, playbackData, drawTrail) {
+  drawTileFromPlaybackData(canvas, playbackData) {
     if (!canvas) {
       return;
     }
-    const size = canvas.zoom > 6 ? 3 : 2;
+    // const size = canvas.zoom > 6 ? 3 : 2;
 
-    const ctx = canvas.ctx;
-    ctx.fillStyle = this.precomputedVesselColor;
-
-    for (let index = 0, lengthData = playbackData.latitude.length; index < lengthData; index++) {
-      this.drawVesselPoint(
-        ctx,
-        playbackData.x[index],
-        playbackData.y[index],
-        size,
-        playbackData.weight[index],
-        playbackData.sigma[index],
-        drawTrail
-      );
-    }
+    this.drawVesselPoints(canvas.ctx, playbackData);
   }
 
   /**
@@ -268,24 +255,8 @@ class CanvasLayer {
       canvas.ctx.clearRect(0, 0, canvas.width, canvas.height);
       return;
     }
-    const ctx = canvas.ctx;
-    ctx.fillStyle = this.precomputedVesselColor;
-    const size = canvas.zoom > 6 ? 3 : 2;
-
-    for (let index = 0, length = vectorArray.latitude.length; index < length; index++) {
-      if (!this.passesFilters(vectorArray, index, true)) {
-        continue;
-      }
-      this.drawVesselPoint(
-        ctx,
-        vectorArray.x[index],
-        vectorArray.y[index],
-        size,
-        vectorArray.weight[index],
-        vectorArray.sigma[index],
-        false
-      );
-    }
+    // const size = canvas.zoom > 6 ? 3 : 2;
+    this.drawVesselPoints(canvas.ctx, vectorArray, true);
   }
 
   /**
@@ -405,6 +376,24 @@ class CanvasLayer {
     return timestamp - (timestamp % TIMELINE_STEP);
   }
 
+  drawVesselPoints(ctx, points, testFilters) {
+    ctx.fillStyle = this.precomputedVesselColor;
+    ctx.beginPath();
+    for (let index = 0, len = points.latitude.length; index < len; index++) {
+      if (testFilters && !this.passesFilters(points, index, true)) {
+        continue;
+      }
+      this.drawVesselPoint(
+        ctx,
+        points.x[index],
+        points.y[index],
+        points.weight[index] /* ,
+        vectorArray.sigma[index] */
+      );
+    }
+    ctx.fill();
+  }
+
   /**
    * Draws a single point representing a vessel
    *
@@ -416,8 +405,10 @@ class CanvasLayer {
    * @param sigma
    * @param drawTrail
    */
-  drawVesselPoint(ctx, x, y, size, weight, sigma, drawTrail) {
-    ctx.fillRect(x, y, size, size);
+  drawVesselPoint(ctx, x, y, weight /*, sigma */) {
+    const radius = Math.max(1, weight / 50);
+    ctx.moveTo(x, y);
+    ctx.arc(x, y, radius, 0, Math.PI * 2, false);
   }
 
   /**

--- a/app/src/components/Layers/CanvasLayer.jsx
+++ b/app/src/components/Layers/CanvasLayer.jsx
@@ -258,7 +258,7 @@ class CanvasLayer {
   }
 
   releaseTile(canvas) {
-    console.log('release tile', canvas.index, this.playbackData.length);
+    // console.log('release tile', canvas.index);
     if (canvas.index === undefined) {
       console.warn('unknown tile relased');
       return;
@@ -315,7 +315,7 @@ class CanvasLayer {
       }
     }
 
-    this._showDebugInfo(canvas.ctx, startIndex);
+    this._showDebugInfo(canvas.ctx, startIndex, canvas.index);
 
   }
 
@@ -466,7 +466,7 @@ class CanvasLayer {
    * @param drawTrail
    */
   drawVesselPoint(ctx, x, y, weight /*, sigma */) {
-    const radius = Math.max(1, weight / 50);
+    const radius = Math.min(5, Math.max(1, Math.round(weight / 10)));
     ctx.moveTo(x, y);
     ctx.arc(x, y, radius, 0, Math.PI * 2, false);
   }

--- a/app/src/components/Layers/CanvasLayer.jsx
+++ b/app/src/components/Layers/CanvasLayer.jsx
@@ -210,8 +210,6 @@ class CanvasLayer {
 
   /**
    * Draws all data in between the given start and end times
-   *
-   *
    * @param start start timstamp (ms)
    * @param end   end timestamp (ms)
    */
@@ -220,6 +218,13 @@ class CanvasLayer {
 
     const startIndex = this._getOffsetedTimeAtPrecision(start);
     const endIndex = this._getOffsetedTimeAtPrecision(end);
+
+    if (this.currentInnerStartIndex === startIndex && this.currentInnerEndIndex === endIndex) {
+      return;
+    }
+
+    this.currentInnerStartIndex = startIndex;
+    this.currentInnerEndIndex = endIndex;
 
     for (let index = 0, length = canvasKeys.length; index < length; index++) {
       const canvasKey = canvasKeys[index];

--- a/app/src/components/Layers/CanvasLayer.jsx
+++ b/app/src/components/Layers/CanvasLayer.jsx
@@ -306,18 +306,16 @@ class CanvasLayer {
     data.x = new Int32Array(data.latitude.length);
     data.y = new Int32Array(data.latitude.length);
 
-    for (let index = 0; index < data.latitude.length; index++) {
-      const pointLatLong = overlayProjection.fromLatLngToPoint(
-        new google.maps.LatLng(data.latitude[index], data.longitude[index])
-      );
+    for (let index = 0, length = data.latitude.length; index < length; index++) {
+      const lat = data.latitude[index];
+      const lng = data.longitude[index];
+      let x = (lng + 180) / 360 * 256;
+      let y = ((1 - Math.log(Math.tan(lat * Math.PI / 180) + 1 / Math.cos(lat * Math.PI / 180)) / Math.PI) / 2 * Math.pow(2, 0)) * 256;
+      x *= scale;
+      y *= scale;
 
-      const pointCoordinates = new google.maps.Point(
-        Math.floor(pointLatLong.x * scale),
-        Math.floor(pointLatLong.y * scale)
-      );
-
-      data.x[index] = ~~((pointCoordinates.x - tileBaseX) << zoomDiff);
-      data.y[index] = ~~((pointCoordinates.y - tileBaseY) << zoomDiff);
+      data.x[index] = ~~((x - tileBaseX) << zoomDiff);
+      data.y[index] = ~~((y - tileBaseY) << zoomDiff);
     }
     return data;
   }

--- a/app/src/components/Map.jsx
+++ b/app/src/components/Map.jsx
@@ -353,7 +353,8 @@ class Map extends Component {
     if (!this.state.overlay) {
       return;
     }
-    this.state.overlay.vesselTransparency = nextProps.map.vesselTransparency;
+    // this.state.overlay.vesselTransparency = nextProps.map.vesselTransparency;
+    this.state.overlay.setVesselTransparency(nextProps.map.vesselTransparency);
 
     if (this.state.running !== 'play') {
       this.state.overlay.refresh();

--- a/app/src/components/Map.jsx
+++ b/app/src/components/Map.jsx
@@ -59,9 +59,6 @@ class Map extends Component {
 
     this.setState({ zoom });
     this.props.setZoom(zoom);
-    if (this.state.overlay) {
-      this.state.overlay.resetPlaybackData();
-    }
     this.updateTrackLayer();
   }
 

--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -15,6 +15,17 @@ export const MAX_ZOOM_LEVEL = 12;
 
 export const DEFAULT_VESSEL_COLOR = '#1181FB';
 
+export const API_RETURNED_KEYS = [
+  'category',
+  'datetime',
+  'latitude',
+  'longitude',
+  'series',
+  'seriesgroup',
+  'sigma',
+  'weight'
+];
+
 export const FLAGS = {
   0: 'AD',
   1: 'AE',

--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -26,6 +26,10 @@ export const API_RETURNED_KEYS = [
   'weight'
 ];
 
+// At which intervals should we consider showing a new frame. Impacts performance.
+// Expressed in ms, for example 86400000 is 1 day (24*60*60*1000)
+export const PLAYBACK_PRECISION = 86400000;
+
 export const FLAGS = {
   0: 'AD',
   1: 'AE',


### PR DESCRIPTION

This PR focuses only on the vessels layer and does the following:
- makes initial post-tile-loading logic ~10 times faster (5s to 500ms). The bottleneck is clearly now tile data loading times, which is something we don't have control over
- makes frame rendering ~5 times faster, which gets us close to 30 fps displaying 100 days worth of vessel points (on my more than average MB pro; Chrome). Note: to achieve this I simplified greatly the drawing sequence, ie all points have the same fill style (opacity and color). Basically, draw-draw-draw-fill, instead of draw-fill-draw-fill-draw-fill.
  - We'll need to see with the client if this is really needed (the question is: can you really make a difference between a .5 and a .7 opacity vessel point?)
  - if this is a requirement, more logic will be needed to group points in opacity buckets (doing draw-draw-draw-fill for each opacity bucket, ie .5, .75 and 1 for example). This will need more work and will have a cost on performance (but it will still be faster than before)
  - points are now drawn with circles instead of little squares, allowing us to easily encode a value in the circle diameter/area
- removes and cleaned up lot of code, plus some stability fixes (tiles not updating, etc)

Next steps:

- revise track layer:
  - logic has to be revised to work with the new time indexes used in vessel layer (currently track layers are broken)
  - optimize performance
  - work on styling (circles should look the same as in the vessel layer, work on colors, line style, etc). check with Dani
  - show tracks on hover as in the prototype?
- vessel layer render style improvements:
  - experiment with different blend modes and check performance costs
  - check with Dani
- We still have gaps/borders between tiles which is due to 2 things:
  - something is wrong with the data (a tile full of points is a neighbour of a tile almost empty). This is due to inconsistencies in the data. Make sure it's not on our side, if not check with the client
  - tile borders are visible because a point drawn too close to the tile limit it will get cut off. The only fix is to use a full screen canvas instead of tiles, but this is a huge change and I'm not sure how it would perform. Check with David Inga
- Fix timeline glitches and figure out outer bounds thing.
