### PR TITLE
Feature/workspace

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,3 +13,4 @@ HOME_SLIDER_JSON_URL=/homeSlider.json
 REQUIRE_MAP_LOGIN=true
 GA_TRACKING_CODE=UA-XXXXXXXX-X
 DEFAULT_WORKSPACE=vizzuality-gfw-integration-default_v1.json
+USE_LOCAL_WORKSPACE=true

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,8 @@
     "ART_PUB_JSON_URL": true,
     "HOME_SLIDER_JSON_URL": true,
     "DEFAULT_WORKSPACE": true,
-    "REQUIRE_MAP_LOGIN": true
+    "REQUIRE_MAP_LOGIN": true,
+    "USE_LOCAL_WORKSPACE": true
   },
   "parserOptions": {
     "ecmaVersion": 7,

--- a/README.md
+++ b/README.md
@@ -136,4 +136,8 @@ Google Analytics tracking code.
 
 #### DEFAULT_WORKSPACE
 
-Name/ID of the default workspace to be loaded on the map
+Name/ID of the default workspace to be loaded on the map (if `USE_LOCAL_WORKSPACE` is set to false, see below)
+
+#### USE_LOCAL_WORKSPACE
+
+Boolean value to determine whether to load by default the workspace defined by `DEFAULT_WORKSPACE` or `public/workspace.json`

--- a/app/src/actions/map.js
+++ b/app/src/actions/map.js
@@ -75,14 +75,13 @@ export function getWorkspace(workspaceId) {
       return;
     }
 
-    /**
-     * If the user isn't logged, we load the default (local) workspace
-     * TODO: load default workspace from server
-     */
-    let url = '/workspace.json';
+    const ID = workspaceId || DEFAULT_WORKSPACE;
+    let url;
 
-    if (workspaceId) {
-      url = `${MAP_API_ENDPOINT}/v1/workspaces/${workspaceId}`;
+    if (!workspaceId && !!USE_LOCAL_WORKSPACE) {
+      url = '/workspace.json';
+    } else {
+      url = `${MAP_API_ENDPOINT}/v1/workspaces/${ID}`;
     }
 
     fetch(url, {
@@ -200,6 +199,7 @@ export function saveWorkspace(errorAction) {
     if (state.user.token) {
       headers.Authorization = `Bearer ${state.user.token}`;
     }
+
 
     fetch(`${MAP_API_ENDPOINT}/v1/workspaces`, {
       method: 'POST',

--- a/app/src/components/AuthMap.jsx
+++ b/app/src/components/AuthMap.jsx
@@ -11,16 +11,12 @@ class AuthMap extends Component {
   }
 
   render() {
-    return (EMBED_MAP_URL) ? <MapIFrameContainer workspaceId={this.props.params.workspace} /> :
-      <MapContainer workspaceId={this.props.params.workspace} />;
+    return (EMBED_MAP_URL) ? <MapIFrameContainer workspaceId={this.props.workspaceId} /> :
+      <MapContainer workspaceId={this.props.workspaceId} />;
   }
 }
 
 AuthMap.propTypes = {
-  /**
-   * Location from React Router Redux
-   */
-  location: React.PropTypes.object,
   /**
    * User token for the map
    */
@@ -34,9 +30,9 @@ AuthMap.propTypes = {
    */
   login: React.PropTypes.func,
   /**
-   * Params from the route
+   * Workspace ID retrieved from the URL
    */
-  params: React.PropTypes.object
+  workspaceId: React.PropTypes.string
 };
 
 export default AuthMap;

--- a/app/src/components/Map.jsx
+++ b/app/src/components/Map.jsx
@@ -46,14 +46,15 @@ class Map extends Component {
    * Resets vessel layer data on change
    */
   onZoomChanged() {
-    if (!this.map) {
-      return;
-    }
+    if (!this.map) return;
+
     let zoom = this.map.getZoom();
+
     if (zoom < MIN_ZOOM_LEVEL) {
       zoom = MIN_ZOOM_LEVEL;
       this.map.setZoom(MIN_ZOOM_LEVEL);
     }
+
     if (zoom > MAX_ZOOM_LEVEL) {
       zoom = MAX_ZOOM_LEVEL;
       this.map.setZoom(MAX_ZOOM_LEVEL);
@@ -61,6 +62,12 @@ class Map extends Component {
 
     this.setState({ zoom });
     this.props.setZoom(zoom);
+
+    // We also need to update the center of the map as it can be changed
+    // when double clicking or scrolling on the map
+    const center = this.map.getCenter();
+    this.props.setCenter([center.lat(), center.lng()]);
+
     this.updateTrackLayer();
   }
 

--- a/app/src/containers/AuthMap.js
+++ b/app/src/containers/AuthMap.js
@@ -5,7 +5,7 @@ import { login } from '../actions/user';
 const mapStateToProps = (state, { location }) => ({
   token: state.user.token,
   canRedirect: location.query && !!location.query.redirect_login,
-  location
+  workspaceId: location.query && location.query.workspace
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/src/reducers/map.js
+++ b/app/src/reducers/map.js
@@ -57,14 +57,36 @@ export default function (state = initialState, action) {
     case CHANGE_VESSEL_TRACK_DISPLAY_MODE:
       return Object.assign({}, state, { vesselTrackDisplayMode: action.payload });
     case TOGGLE_LAYER_VISIBILITY: {
-      const layers = state.layers.slice(0);
-      for (let i = 0, length = layers.length; i < length; i++) {
-        if (layers[i].title === action.payload.title) {
-          layers[i].visible = !action.payload.visible;
-          break;
+      // We get the index of the layer to update
+      const layerIndex = state.layers.reduce((res, l, i) => {
+        if (l.title === action.payload.title) {
+          return i;
         }
+        return res;
+      }, -1);
+
+      // If the layer couldn't be found, we don't make any change
+      if (layerIndex === -1) return state;
+
+      const newLayer = Object.assign({}, state.layers[layerIndex], {
+        visible: !state.layers[layerIndex].visible
+      });
+
+      let newLayers;
+      if (layerIndex === 0) {
+        if (state.layers.length === 1) {
+          newLayers = [newLayer];
+        } else {
+          newLayers = [newLayer].concat(state.layers.slice(1, state.layers.length));
+        }
+      } else if (layerIndex === state.layers.length - 1) {
+        newLayers = state.layers.slice(0, state.layers.length - 1).concat([newLayer]);
+      } else {
+        newLayers = state.layers.slice(0, layerIndex).concat([newLayer],
+          state.layers.slice(layerIndex + 1, state.layers.length));
       }
-      return Object.assign({}, state, { layers });
+
+      return Object.assign({}, state, { layers: newLayers });
     }
 
     case SHARE_MODAL_OPEN: {

--- a/app/src/routes.jsx
+++ b/app/src/routes.jsx
@@ -102,7 +102,7 @@ class Routes extends Component {
         <Route path="/" component={AppContainer}>
           <IndexRoute component={HomeContainer} />
 
-          <Route path="map(/workspace/:workspace)" component={AuthMapContainer} />
+          <Route path="map" component={AuthMapContainer} />
 
           <Route path="articles-publications" component={ArticlesPublications} />
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -51,6 +51,7 @@ const webpackConfig = {
       ART_PUB_JSON_URL: JSON.stringify(envVariables.ART_PUB_JSON_URL),
       REQUIRE_MAP_LOGIN: envVariables.REQUIRE_MAP_LOGIN,
       DEFAULT_WORKSPACE: JSON.stringify(envVariables.DEFAULT_WORKSPACE),
+      USE_LOCAL_WORKSPACE: JSON.stringify(envVariables.USE_LOCAL_WORKSPACE),
       GA_TRACKING_CODE: JSON.stringify(envVariables.GA_TRACKING_CODE),
       HOME_SLIDER_JSON_URL: JSON.stringify(envVariables.HOME_SLIDER_JSON_URL)
     })


### PR DESCRIPTION
This PR makes the workspace great again (*) by addressing several related issues:
* The `workspace` param isn't part of the URL anymore but just a query param that's why it wouldn't load
* The map reducer would mutate redux' state when the user would toggle the visibility of a layer
* The method to detect the layer visibility changes has been rewritten due to several flaws and errors (and got a 40% time improvements; the load time of the map has been reduced by... 1ms! 🎉)
* The position of the new center of the map wouldn't be saved when the map would be zoomed

(*) The vessels layer can't be toggled, causing the workspace to not work with it (see the [task on Pivotal](https://www.pivotaltracker.com/story/show/133935067))