### PR TITLE
Fixed error related with vessel layers

### DIFF
--- a/app/src/components/Map.jsx
+++ b/app/src/components/Map.jsx
@@ -24,7 +24,7 @@ class Map extends Component {
     super(props);
     this.state = {
       overlay: null,
-      addedLayers: [],
+      addedLayers: {},
       lastCenter: null,
       running: 'stop'
     };
@@ -306,25 +306,27 @@ class Map extends Component {
     const layers = this.state.addedLayers;
 
     if (layerSettings.visible) {
-      if (layers[layerSettings.title].isVisible()) {
-        return;
-      }
       if (layerSettings.type === 'ClusterAnimation') {
         // TODO
         // this.state.overlay.show();
-      } else {
-        layers[layerSettings.title].show();
-      }
-    } else {
-      if (!layers[layerSettings.title].isVisible()) {
         return;
       }
+
+      if (layers[layerSettings.title].isVisible()) return;
+
+      console.info(`showing layer: ${layerSettings.title}`);
+      layers[layerSettings.title].show();
+    } else {
       if (layerSettings.type === 'ClusterAnimation') {
         // TODO
         // this.state.overlay.hide();
-      } else {
-        layers[layerSettings.title].hide();
+        return;
       }
+
+      if (!layers[layerSettings.title].isVisible()) return;
+
+      console.info(`hiding layer: ${layerSettings.title}`);
+      layers[layerSettings.title].hide();
     }
   }
 


### PR DESCRIPTION
Pivotal task: https://www.pivotaltracker.com/story/show/134395665

The error was produced because `ClusterAnimation`-typed layers were trying to access to the method `isVisible` of CARTODB layers.

Also, the property `addedLayers ` of `this.state` was initially an array. Now it's an object. Otherwise, when the app added layers with methods like `addCartoBasemap` or `addCartoLayer`, instead of pushing the layer into the array, the layer was setted as a property of the array, which can be really confusing.