### PR TITLE
limit inner extent to 6 months

### DIFF
--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -11,6 +11,7 @@ export const TIMELINE_TOTAL_DATE_EXTENT = [new Date(Date.UTC(2012, 0, 1)), new D
 export const TIMELINE_INNER_EXTENT = [new Date(Date.UTC(2015, 0, 1)), new Date(Date.UTC(2015, 0, 30))];
 
 export const TIMELINE_MAX_STEPS = 190; // six months
+export const TIMELINE_MAX_TIME = TIMELINE_STEP * TIMELINE_MAX_STEPS; // six months
 
 export const MIN_ZOOM_LEVEL = 2;
 export const MAX_ZOOM_LEVEL = 12;


### PR DESCRIPTION
Limit the display range to 6 months to avoid locking the UI for too long.