### PR TITLE
optimize webpack image processor

### DIFF
--- a/app/src/components/Map.jsx
+++ b/app/src/components/Map.jsx
@@ -174,8 +174,6 @@ class Map extends Component {
 
     this.updateVesselTransparency(nextProps);
     this.updateVesselColor(nextProps);
-
-
   }
 
   /**

--- a/app/src/components/Map/Timebar.jsx
+++ b/app/src/components/Map/Timebar.jsx
@@ -227,12 +227,13 @@ class Timebar extends Component {
   getNewOuterExtent(newOuterPxExtent) {
     // use the new x scale to compute new time values
     // do not get out of total range for outer brush
+    const propsTimelineOverallExtent = this.props.filters.timelineOverallExtent;
     const newOuterTimeLeft = x.invert(newOuterPxExtent[0]);
     const newOuterTimeRight = x.invert(newOuterPxExtent[1]);
-    const isAfterOverallStartDate = newOuterTimeLeft.getTime() > this.props.filters.timelineOverallExtent[0].getTime();
-    const isBeforeOverallEndDate = newOuterTimeRight.getTime() < this.props.filters.timelineOverallExtent[1].getTime();
-    const newOuterTimeExtentLeft = isAfterOverallStartDate ? newOuterTimeLeft : this.props.filters.timelineOverallExtent[0];
-    const newOuterTimeExtentRight = isBeforeOverallEndDate ? newOuterTimeRight : this.props.filters.timelineOverallExtent[1];
+    const isAfterOverallStartDate = newOuterTimeLeft.getTime() > propsTimelineOverallExtent[0].getTime();
+    const isBeforeOverallEndDate = newOuterTimeRight.getTime() < propsTimelineOverallExtent[1].getTime();
+    const newOuterTimeExtentLeft = isAfterOverallStartDate ? newOuterTimeLeft : propsTimelineOverallExtent[0];
+    const newOuterTimeExtentRight = isBeforeOverallEndDate ? newOuterTimeRight : propsTimelineOverallExtent[1];
     return [newOuterTimeExtentLeft, newOuterTimeExtentRight];
   }
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -82,7 +82,7 @@ const webpackConfig = {
         test: /\.(jpe?g|png|gif|svg)$/i,
         loaders: [
           'file?hash=sha512&digest=hex&name=[hash].[ext]',
-          'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false'
+          'image-webpack'
         ]
       },
       {
@@ -96,6 +96,11 @@ const webpackConfig = {
     ]
   },
 
+  imageWebpackLoader: {
+    optimizationLevel: (process.env.NODE_ENV === 'development' ? 0 : 7),
+    bypassOnDebug: true,
+    interlaced: false
+  },
   postcss() {
     return [autoprefixer];
   }


### PR DESCRIPTION
This shaved off 5 seconds from the build time, but it's still taking 18 seconds on a cold webpack cache