### PR TITLE
Improce inner time range extend behavior

### DIFF
--- a/app/src/components/Map/Timebar.jsx
+++ b/app/src/components/Map/Timebar.jsx
@@ -305,10 +305,10 @@ class Timebar extends Component {
 
       if (oldExtent[0].getTime() === newExtent[0].getTime()) {
         // right brush was moved
-        newExtent[1] = oldExtent[1];
+        newExtent[1] = new Date(oldExtent[0].getTime() + TIMELINE_MAX_TIME);
       } else {
         // left brush was moved
-        newExtent[0] = oldExtent[0];
+        newExtent[0] = new Date(oldExtent[1].getTime() - TIMELINE_MAX_TIME);
       }
       newExtentPx = this.getPxExtent(newExtent);
       this.redrawInnerBrush(newExtent);


### PR DESCRIPTION
Currently, if you extend the inner brush beyond the limit (configured to 6 months), it snaps back to the old value. This is kind of annoying, and I believe that it should instead stay at the max width of the inner range
