### PR TITLE
fixed timebar/sidebar overlap issue

### DIFF
--- a/app/src/components/Map/Timebar.jsx
+++ b/app/src/components/Map/Timebar.jsx
@@ -322,7 +322,7 @@ class Timebar extends Component {
       durationPickerExtent: newExtent
     });
     this.redrawInnerBrushCircles(newExtentPx);
-    this.redrawInnerBrushFooter(newExtentPx);
+    this.redrawDurationPicker(newExtentPx);
   }
 
   redrawInnerBrush(newInnerExtent) {
@@ -331,9 +331,8 @@ class Timebar extends Component {
     this.disableInnerBrush();
     this.innerBrushFunc.move(this.innerBrush, currentInnerPxExtent);
     this.redrawInnerBrushCircles(currentInnerPxExtent);
-    this.redrawInnerBrushFooter(currentInnerPxExtent);
+    this.redrawDurationPicker(currentInnerPxExtent);
     this.enableInnerBrush();
-    // this.updateDurationPicker();
   }
 
   redrawInnerBrushCircles(newInnerPxExtent) {
@@ -341,7 +340,7 @@ class Timebar extends Component {
     innerBrushRightCircle.attr('cx', newInnerPxExtent[1]);
   }
 
-  redrawInnerBrushFooter(newInnerPxExtent) {
+  redrawDurationPicker(newInnerPxExtent) {
     this.setState({
       innerExtentPx: newInnerPxExtent
     });

--- a/app/styles/components/map/c-durationpicker.scss
+++ b/app/styles/components/map/c-durationpicker.scss
@@ -13,7 +13,7 @@
   position: absolute;
   text-align: center;
   top: 0;
-  z-index: 99;
+  z-index: 5;
 
   .c-durationpicker-text {
     display: inline-block;


### PR DESCRIPTION
![screen shot 2016-12-12 at 16 12 11](https://cloud.githubusercontent.com/assets/1583415/21104181/e0a5ece0-c085-11e6-9f11-ee2f136bc6a6.png)

Timebar should be behind sidebar, because you can always collapse sidebar to let the timebar show up.
Also it's way simpler to fix.