### PR TITLE
Filtered predefined range time based on timebar current range

### DIFF
--- a/app/src/components/Map/DurationPicker.jsx
+++ b/app/src/components/Map/DurationPicker.jsx
@@ -80,15 +80,24 @@ class DurationPicker extends Component {
   }
 
   render() {
+    let filterFunc = null;
     const humanizedDuration = this.getHumanizedDuration(this.state.extent);
     const style = {
       width: this.getWidth(this.props.extentPx),
       left: this.getLeft(this.props.extentPx)
     };
 
+    // filters predefined time ranges to avoid overlapping the whole timebar
+    // when its range is lesser than the available options
+    if (this.props.timelineOuterExtent) {
+      const diffTime = moment.duration(this.props.timelineOuterExtent[1] - this.props.timelineOuterExtent[0]);
+      filterFunc = (duration) => moment.duration(diffTime) >= duration;
+    }
+
     let durations;
     if (this.state.showSettingsMenu) {
-      durations = DURATION_PICKER_OPTIONS.map((duration, i) =>
+      durations = DURATION_PICKER_OPTIONS.filter(filterFunc)
+      .map((duration, i) =>
         (<li
           className={css['settings-item']}
           data-index={i}
@@ -129,6 +138,7 @@ class DurationPicker extends Component {
 DurationPicker.propTypes = {
   extent: React.PropTypes.array,
   extentPx: React.PropTypes.array,
+  timelineOuterExtent: React.PropTypes.array,
   onTimeRangeSelected: React.PropTypes.func
 };
 

--- a/app/src/components/Map/Timebar.jsx
+++ b/app/src/components/Map/Timebar.jsx
@@ -560,6 +560,7 @@ class Timebar extends Component {
           <DurationPicker
             extent={this.state.durationPickerExtent}
             extentPx={this.state.innerExtentPx}
+            timelineOuterExtent={this.props.filters.timelineOuterExtent}
             onTimeRangeSelected={(rangeTime) => this.onTimeRangeSelected(rangeTime)}
           />
         </div>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/999124/21343528/5f730488-c697-11e6-8f6c-a9c9f5314364.png)

This PR filters predefined range times based on the current timebar. In the above picture the timebar range is lesser than a month, that's why in the predefined range times only the options `15 days` and `7 days` are available.