### PR TITLE
Avoid unmount component when its not initialized

### DIFF
--- a/app/src/components/Map/Timebar.jsx
+++ b/app/src/components/Map/Timebar.jsx
@@ -99,6 +99,8 @@ class Timebar extends Component {
   }
 
   componentWillUnmount() {
+    if (!this.svg) return;
+
     outerBrushHandleLeft.on('mousedown', null);
     outerBrushHandleRight.on('mousedown', null);
     d3.select('body').on('mousemove', null);


### PR DESCRIPTION
For some reason, when I clicked on "Back to homepage" link, in the no-login modal, it triggered the `componentWillUnmount` function of the timebar "breaking" the link and forcing to the user to click a second time to go back to the homepage.  

It brokes because all variables used on that function weren't initialized. Now, I ask if the timebar is already initialized before do anything.