### PR TITLE
Temporal fix for Safari accordion animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-router": "^2.4.1",
     "react-router-redux": "^4.0.4",
     "react-router-scroll": "^0.3.2",
-    "react-sanfona": "0.0.15",
+    "react-sanfona": "daviferreira/react-sanfona#transitionfix",
     "react-slick": "^0.13.6",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-router": "^2.4.1",
     "react-router-redux": "^4.0.4",
     "react-router-scroll": "^0.3.2",
-    "react-sanfona": "daviferreira/react-sanfona#transitionfix",
+    "react-sanfona": "daviferreira/react-sanfona#086ef6dd3db5fa8b6cc357e9d9c580fce4053c17",
     "react-slick": "^0.13.6",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",


### PR DESCRIPTION
Personally I don't like the idea of pointing to a specific branch but as we don't know when the owner of the project will merge it this is the only solution meanwhile. If the branch is merged we'll have to change this value to the previous one again.

With this change, Safari accordion animations are fixed for Safari desktop, iPad and iPhone.

Don't forget to remove your `react-sanfona` folder in `node_modules` and `npm i` to install the new version.