### PR TITLE
Restored Marine Traffic link

### DIFF
--- a/app/src/components/Map/VesselInfoPanel.jsx
+++ b/app/src/components/Map/VesselInfoPanel.jsx
@@ -92,10 +92,10 @@ class VesselInfoPanel extends Component {
               </ul>
             </div>
           }
-          {vesselInfo.link && <a
+          {vesselInfo.mmsi && <a
             className={vesselPanelStyles['external-link']}
             target="_blank"
-            href={vesselInfo.link}
+            href={`http://www.marinetraffic.com/en/ais/details/ships/mmsi:${vesselInfo.mmsi}`}
           >Check it on MarineTraffic.com
           </a>
           }

--- a/app/styles/components/c-vessel-info-panel.scss
+++ b/app/styles/components/c-vessel-info-panel.scss
@@ -47,6 +47,7 @@
       font-family: $font-family-1;
       font-size: $font-size-xxs-small;
       margin: 15px 0 0;
+      text-decoration: underline;
     }
 
     .rfmo-list {


### PR DESCRIPTION
Pivotal task: https://www.pivotaltracker.com/story/show/136898451

The link wasn't showing because they removed the `link` params which provides it.

As the Marine Traffic link is composed by an static part and the `MMSI` is fine for us to build the link ourselves. Enrique is talking about sending the info through API, but this is not necessary if the format is always the same. Let me know your opinion.