### PR TITLE
Added RFMO links

### DIFF
--- a/app/src/components/Map/VesselInfoPanel.jsx
+++ b/app/src/components/Map/VesselInfoPanel.jsx
@@ -10,8 +10,26 @@ class VesselInfoPanel extends Component {
 
   render() {
     let vesselInfoContents = null;
+    let RFMORegistry = null;
     const visibilityClass = this.props.vesselVisibility ? null : helperStyles['_is-hidden'];
     const vesselInfo = this.props.vesselInfo;
+
+    if (vesselInfo.rfmo_registry_info) {
+      RFMORegistry = [];
+      vesselInfo.rfmo_registry_info.forEach((registry) => {
+        RFMORegistry.push(
+          <li className={vesselPanelStyles['rfmo-item']}>
+            <a
+              className={vesselPanelStyles['external-link']}
+              href={`${registry.url}`}
+              target="_blank"
+            >
+              {registry.rfmo}
+            </a>
+          </li>
+        );
+      });
+    }
 
     if (vesselInfo === null || vesselInfo.isCluster || vesselInfo.isLoading) {
       let message;
@@ -66,6 +84,14 @@ class VesselInfoPanel extends Component {
             <span className={vesselPanelStyles.key}>Callsign</span>
             <span className={vesselPanelStyles.value}>{vesselInfo.callsign || '---'}</span>
           </div>
+          {RFMORegistry &&
+            <div className={vesselPanelStyles['row-info']}>
+              <span className={vesselPanelStyles.key}>RFMO</span>
+              <ul className={vesselPanelStyles['rfmo-list']}>
+                {RFMORegistry}
+              </ul>
+            </div>
+          }
           {vesselInfo.link && <a
             className={vesselPanelStyles['external-link']}
             target="_blank"

--- a/app/styles/components/c-vessel-info-panel.scss
+++ b/app/styles/components/c-vessel-info-panel.scss
@@ -40,12 +40,30 @@
       }
     }
 
+
     .external-link {
       color: $color-3;
       display: inline-block;
       font-family: $font-family-1;
       font-size: $font-size-xxs-small;
       margin: 15px 0 0;
+    }
+
+    .rfmo-list {
+      display: flex;
+      flex-wrap: wrap;
+
+      > .rfmo-item {
+        width: calc(50% - 3px);
+
+        &:nth-child(2n) {
+          margin: 0 0 0 6px;
+        }
+      }
+
+      > .rfmo-item > .external-link {
+        margin: 10px 0 0;
+      }
     }
 
     .zoom {


### PR DESCRIPTION
Pivotal task: https://www.pivotaltracker.com/story/show/136898497

![image](https://cloud.githubusercontent.com/assets/999124/21771325/344bb912-d687-11e6-9b87-27e618693bf5.png)

At this moment, API is NOT providing RFMO links info so I faked them temporally to implement and style them and take a picture of how it would look. Fields are based on [this comment](https://www.pivotaltracker.com/story/show/136898497/comments/159307455).