### PR TITLE
fixed offset issue at high z levels

### DIFF
--- a/app/src/actions/heatmap.js
+++ b/app/src/actions/heatmap.js
@@ -17,7 +17,7 @@ import {
 import { getVesselTrack, setCurrentVessel, showVesselClusterInfo, showNoVesselsInfo, clearTrack } from 'actions/vesselInfo';
 
 
-export function getTile(uid, tileCoordinates, canvas) {
+export function getTile(uid, tileCoordinates, canvas, map) {
   return (dispatch, getState) => {
     const layers = getState().heatmap;
     const timelineOverallStartDate = getState().filters.timelineOverallExtent[0];
@@ -52,7 +52,8 @@ export function getTile(uid, tileCoordinates, canvas) {
       allLayerPromises.then(rawTileData => {
         const cleanVectorArrays = getCleanVectorArrays(rawTileData);
         const groupedData = groupData(cleanVectorArrays);
-        const vectorArray = addTilePixelCoordinates(tileCoordinates, groupedData);
+        const bounds = tile.canvas.getBoundingClientRect();
+        const vectorArray = addTilePixelCoordinates(groupedData, map, bounds);
         const data = getTilePlaybackData(
           tileCoordinates.zoom,
           vectorArray,

--- a/app/src/components/Layers/MapLayers.jsx
+++ b/app/src/components/Layers/MapLayers.jsx
@@ -129,7 +129,7 @@ class MapLayers extends Component {
   }
 
   initHeatmap() {
-    this.tiledLayer = new TiledLayer(this.props.createTile, this.props.releaseTile);
+    this.tiledLayer = new TiledLayer(this.props.createTile, this.props.releaseTile, this.map);
     this.map.overlayMapTypes.insertAt(0, this.tiledLayer);
     this.heatmapContainer = new HeatmapContainer(this.props.viewportWidth, this.props.viewportHeight);
     this.heatmapContainer.setMap(this.map);

--- a/app/src/components/Layers/TiledLayer.js
+++ b/app/src/components/Layers/TiledLayer.js
@@ -1,5 +1,6 @@
 export default class TiledLayer {
-  constructor(getTileCallback, releaseTileCallback) {
+  constructor(getTileCallback, releaseTileCallback, map) {
+    this.map = map;
     this.getTileCallback = getTileCallback;
     this.releaseTileCallback = releaseTileCallback;
     this.tileSize = new google.maps.Size(256, 256);
@@ -54,8 +55,10 @@ export default class TiledLayer {
       return canvas;
     }
 
+    canvas.map = this.map;
+
     canvas.uid = this.currentUid;
-    this.getTileCallback(this.currentUid, tileCoordinates, canvas);
+    this.getTileCallback(this.currentUid, tileCoordinates, canvas, this.map);
     this.tiles.push(canvas);
     this.currentUid++;
     return canvas;

--- a/app/src/containers/Layers/MapLayers.js
+++ b/app/src/containers/Layers/MapLayers.js
@@ -24,8 +24,8 @@ const mapDispatchToProps = (dispatch) => ({
   showPolygon: (id, description, latLng) => {
     dispatch(showPolygon(id, description, latLng));
   },
-  createTile: (uid, coordinates, canvas) => {
-    dispatch(getTile(uid, coordinates, canvas));
+  createTile: (uid, coordinates, canvas, map) => {
+    dispatch(getTile(uid, coordinates, canvas, map));
   },
   releaseTile: (uid) => {
     dispatch(releaseTile(uid));

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -38,7 +38,7 @@
         {
           "title": "VESSEL",
           "description": "Fishing effort layer (fr)",
-          "url": "https://api-dot-world-fishing-827.appspot.com/v1/tilesets/801-tileset-nz2-tms",
+          "url": "https://api-dot-world-fishing-827.appspot.com/v1/tilesets/849-tileset-tms",
           "visible": true,
           "color": "#88FBFF",
           "hue": 182,


### PR DESCRIPTION
Replaced our hacky coordinates calculation with standard GMaps APIs, which will be slower, but it's done 'offline' (only once after tile loading) so it's barely visible (especially since we are still loading all years at once), but we might want to try to revise that at a later stage