### PR TITLE
Feature/endpoints

### DIFF
--- a/app/src/actions/layers.js
+++ b/app/src/actions/layers.js
@@ -6,7 +6,6 @@ import {
   TOGGLE_LAYER_WORKSPACE_PRESENCE,
   SET_LAYER_OPACITY,
   SET_LAYER_HUE,
-  SET_TILESET_URL,
   SET_MAX_ZOOM,
   SET_OVERALL_TIMELINE_DATES,
   UPLOAD_USER_LAYER
@@ -50,18 +49,6 @@ export function initLayers(workspaceLayers, libraryLayers) {
       }
     });
 
-    const vesselLayer = workspaceLayers
-      .filter(l => l.type === LAYER_TYPES.ClusterAnimation)[0];
-
-    if (vesselLayer !== undefined) {
-      // TODO: we should probably store this somewhere else on the WS
-      const tilesetUrl = vesselLayer.url;
-
-      dispatch({
-        type: SET_TILESET_URL,
-        payload: tilesetUrl
-      });
-    }
     dispatch({
       type: SET_LAYERS,
       payload: workspaceLayers
@@ -102,11 +89,6 @@ export function loadTilesetMetadata(tilesetUrl) {
           });
         }
       });
-
-    dispatch({
-      type: SET_TILESET_URL,
-      payload: tilesetUrl
-    });
   };
 }
 

--- a/app/src/actions/report.js
+++ b/app/src/actions/report.js
@@ -92,9 +92,6 @@ export function sendReport() {
       return;
     }
 
-    // TODO hardcoded, will need to check w/ Skytruth for how to retrieve that properly
-    const tileset = '801-tileset-nz2-tms';
-    const url = `${MAP_API_ENDPOINT}/v1/tilesets/${tileset}/reports`;
     const payload = {
       from: state.filters.timelineInnerExtent[0].toISOString(),
       to: state.filters.timelineInnerExtent[1].toISOString()
@@ -121,7 +118,7 @@ export function sendReport() {
         Authorization: `Bearer ${state.user.token}`
       };
     }
-    fetch(url, options).then((res) => {
+    fetch(`${state.map.tilesetUrl}/reports`, options).then((res) => {
       if (!res.ok) {
         throw Error(res.statusText);
       }

--- a/app/src/actions/workspace.js
+++ b/app/src/actions/workspace.js
@@ -63,7 +63,7 @@ function processNewWorkspace(data) {
     layers: workspace.map.layers,
     flagFilters: workspace.map.flagFilters,
     pinnedVessels: workspace.pinnedVessels,
-    tilesetUrl: workspace.tilesetUrl
+    tilesetUrl: `${MAP_API_ENDPOINT}/v1/tilesets/${workspace.tileset}`
   };
 }
 

--- a/app/src/actions/workspace.js
+++ b/app/src/actions/workspace.js
@@ -5,7 +5,7 @@ import {
   TIMELINE_DEFAULT_INNER_START_DATE,
   TIMELINE_DEFAULT_INNER_END_DATE
 } from 'constants';
-import { SET_ZOOM, SET_CENTER, SET_INNER_TIMELINE_DATES, SET_OUTER_TIMELINE_DATES, SET_BASEMAP } from 'actions';
+import { SET_ZOOM, SET_CENTER, SET_INNER_TIMELINE_DATES, SET_OUTER_TIMELINE_DATES, SET_BASEMAP, SET_TILESET_URL } from 'actions';
 import { initLayers, loadTilesetMetadata } from 'actions/layers';
 import { setFlagFilters } from 'actions/filters';
 import { setPinnedVessels } from 'actions/vesselInfo';
@@ -37,6 +37,11 @@ function dispatchActions(workspaceData, dispatch, getState) {
     type: SET_BASEMAP, payload: workspaceData.basemap
   });
 
+  dispatch({
+    type: SET_TILESET_URL,
+    payload: workspaceData.tilesetUrl
+  });
+
   dispatch(loadTilesetMetadata(workspaceData.tilesetUrl));
 
   dispatch(initLayers(workspaceData.layers, state.layerLibrary.layers));
@@ -49,10 +54,6 @@ function dispatchActions(workspaceData, dispatch, getState) {
 function processNewWorkspace(data) {
   const workspace = data.workspace;
 
-  const vesselLayer = workspace.map.layers
-    .filter(l => l.type === LAYER_TYPES.ClusterAnimation)[0];
-  const tilesetUrl = vesselLayer.url;
-
   return {
     zoom: workspace.map.zoom,
     center: workspace.map.center,
@@ -62,7 +63,7 @@ function processNewWorkspace(data) {
     layers: workspace.map.layers,
     flagFilters: workspace.map.flagFilters,
     pinnedVessels: workspace.pinnedVessels,
-    tilesetUrl
+    tilesetUrl: workspace.tilesetUrl
   };
 }
 

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -1,5 +1,6 @@
 {
   "workspace": {
+    "tilesetUrl": "https://api-dot-world-fishing-827.appspot.com/v1/tilesets/849-tileset-tms",
     "map": {
       "center": [
         0,

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -1,6 +1,6 @@
 {
   "workspace": {
-    "tilesetUrl": "https://api-dot-world-fishing-827.appspot.com/v1/tilesets/849-tileset-tms",
+    "tileset": "849-tileset-tms",
     "map": {
       "center": [
         0,


### PR DESCRIPTION
This aims at using a single tileset endpoint through the whole map, defined in the workspace (the base URL is defined in env vars)

@tiagojsag I thought of putting endpoints final bits like `/search`, `/reports` in env vars or workspace too, but the right way would be to have those URLs directly from an API response anyways, so I haven't bothered.