### PR TITLE
Added social functions

### DIFF
--- a/app/src/components/Map/Share.jsx
+++ b/app/src/components/Map/Share.jsx
@@ -60,15 +60,21 @@ class Share extends Component {
   }
 
   openFacebook() {
-    console.info('Facebook share coming soon...');
+    const url = this.getURLWithWorkspace();
+
+    window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`);
   }
 
   openGooglePlus() {
-    console.info('Google Plus share coming soon...');
+    const url = this.getURLWithWorkspace();
+
+    window.open(`https://plus.google.com/share?url=${url}`);
   }
 
   openTwitter() {
-    console.info('Twitter share coming soon...');
+    const url = this.getURLWithWorkspace();
+
+    window.open(`https://twitter.com/share?url=${url}`);
   }
 
   render() {

--- a/app/styles/components/map/c-share.scss
+++ b/app/styles/components/map/c-share.scss
@@ -92,6 +92,7 @@
     > .social-button {
       border: 0;
       cursor: pointer;
+      outline: 0;
       padding: 24px 0;
 
       &:not(:first-child) {


### PR DESCRIPTION
Facebook and G+ button don't work because of localhost. Twitter one just copy and paste the URL argument, it can be customized  with a text. This functionality just share, it doesn't track anything or add "likes" or "+1" in cases of Facebook and G+.