### PR TITLE
Fix/blending tooltips

### DIFF
--- a/app/src/components/Layers/TracksLayer.js
+++ b/app/src/components/Layers/TracksLayer.js
@@ -103,6 +103,7 @@ export default class TracksLayerGL {
       // this.stage.drawCircle(circlePoints.inner.x[i], circlePoints.inner.y[i], circlePoints.inner.radius[i]);
       this.stage.drawCircle(circlePoints.inner.x[i], circlePoints.inner.y[i], 2);
     }
+    this.stage.endFill();
     // // inner range glow
     // this.stage.beginFill(color, 0.1);
     // for (let i = 0, circlesLength = circlePoints.inner.x.length; i < circlesLength; i++) {
@@ -115,6 +116,7 @@ export default class TracksLayerGL {
       // this.stage.drawCircle(circlePoints.over.x[i], circlePoints.over.y[i], circlePoints.inner.radius[i]);
       this.stage.drawCircle(circlePoints.over.x[i], circlePoints.over.y[i], 2);
     }
+    this.stage.endFill();
     // // over range glow
     // this.stage.beginFill('0xFFFFFF', 0.1);
     // for (let i = 0, circlesLength = circlePoints.over.x.length; i < circlesLength; i++) {

--- a/app/src/components/Layers/TracksLayer.js
+++ b/app/src/components/Layers/TracksLayer.js
@@ -97,31 +97,20 @@ export default class TracksLayerGL {
     }
 
     this.stage.lineStyle(0);
+
     // inner range center circle
     this.stage.beginFill('0xFFFFFF', 1);
     for (let i = 0, circlesLength = circlePoints.inner.x.length; i < circlesLength; i++) {
-      // this.stage.drawCircle(circlePoints.inner.x[i], circlePoints.inner.y[i], circlePoints.inner.radius[i]);
       this.stage.drawCircle(circlePoints.inner.x[i], circlePoints.inner.y[i], 2);
     }
     this.stage.endFill();
-    // // inner range glow
-    // this.stage.beginFill(color, 0.1);
-    // for (let i = 0, circlesLength = circlePoints.inner.x.length; i < circlesLength; i++) {
-    //   this.stage.drawCircle(circlePoints.inner.x[i], circlePoints.inner.y[i], 10);
-    // }
 
     // over range center circle
     this.stage.beginFill('0xFFFFFF', 1);
     for (let i = 0, circlesLength = circlePoints.over.x.length; i < circlesLength; i++) {
-      // this.stage.drawCircle(circlePoints.over.x[i], circlePoints.over.y[i], circlePoints.inner.radius[i]);
       this.stage.drawCircle(circlePoints.over.x[i], circlePoints.over.y[i], 2);
     }
     this.stage.endFill();
-    // // over range glow
-    // this.stage.beginFill('0xFFFFFF', 0.1);
-    // for (let i = 0, circlesLength = circlePoints.over.x.length; i < circlesLength; i++) {
-    //   this.stage.drawCircle(circlePoints.over.x[i], circlePoints.over.y[i], 10);
-    // }
   }
 
   getDrawStyle(timestamp, { startTimestamp, endTimestamp, overStartTimestamp, overEndTimestamp }) {

--- a/app/src/components/Map/FilterItem.jsx
+++ b/app/src/components/Map/FilterItem.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import LayerOptionsTooltip from 'components/Map/LayerOptionsTooltip';
+import LayerBlendingOptionsTooltip from 'components/Map/LayerBlendingOptionsTooltip';
 import classnames from 'classnames';
 import { REVERSE_TOOLTIP_FILTERS_MOBILE } from 'constants';
 
@@ -68,13 +68,14 @@ class FilterItem extends Component {
                 { [`${IconStyles['-white']}`]: this.props.showBlending === true })}
                 onClick={() => this.toggleBlending()}
               />
-              <LayerOptionsTooltip
+              {this.props.showBlending &&
+              <LayerBlendingOptionsTooltip
                 displayHue
                 hueValue={hueValue}
                 onChangeHue={hue => this.onChangeHue(hue)}
-                showBlending={this.props.showBlending}
                 isReverse={this.props.index < REVERSE_TOOLTIP_FILTERS_MOBILE}
               />
+              }
             </li>
             <li className={flagFilterStyles['filter-option-item']}>
               <RemoveFilterIcon

--- a/app/src/components/Map/LayerBlendingOptionsTooltip.jsx
+++ b/app/src/components/Map/LayerBlendingOptionsTooltip.jsx
@@ -66,13 +66,10 @@ class LayerOptionsTooltip extends Component {
   }
 
   render() {
-    // if (!this.state.opacityRangeValue) return null;
-
     return (
       <div
         className={classnames(
           BlendingStyles['c-blending'],
-          { [`${BlendingStyles['-is-visible']}`]: this.props.showBlending },
           { [`${BlendingStyles['-reverse']}`]: this.props.isReverse })
         }
       >
@@ -107,10 +104,9 @@ LayerOptionsTooltip.propTypes = {
   displayHue: React.PropTypes.bool,
   displayOpacity: React.PropTypes.bool,
   hueValue: React.PropTypes.number,
+  opacityValue: React.PropTypes.number,
   onChangeHue: React.PropTypes.func,
   onChangeOpacity: React.PropTypes.func,
-  opacityValue: React.PropTypes.number,
-  showBlending: React.PropTypes.bool,
   isReverse: React.PropTypes.bool
 };
 

--- a/app/src/components/Map/LayerItem.jsx
+++ b/app/src/components/Map/LayerItem.jsx
@@ -92,9 +92,9 @@ class LayerItem extends Component {
           </li>}
           {this.props.layer.type !== LAYER_TYPES.Custom && <li
             className={LayerListStyles['layer-option-item']}
-            onClick={() => this.toggleBlending()}
           >
             <BlendingIcon
+              onClick={() => this.toggleBlending()}
               className={classnames(icons['blending-icon'],
                 { [`${icons['-white']}`]: this.props.showBlending })}
             />

--- a/app/src/components/Map/LayerItem.jsx
+++ b/app/src/components/Map/LayerItem.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { LAYER_TYPES, REVERSE_TOOLTIP_ITEMS_MOBILE } from 'constants';
-import LayerOptionsTooltip from 'components/Map/LayerOptionsTooltip';
+import LayerBlendingOptionsTooltip from 'components/Map/LayerBlendingOptionsTooltip';
 import LayerListStyles from 'styles/components/map/c-layer-list.scss';
 import icons from 'styles/icons.scss';
 import ReportIcon from 'babel!svg-react!assets/icons/report-icon.svg?name=ReportIcon';
@@ -98,16 +98,17 @@ class LayerItem extends Component {
               className={classnames(icons['blending-icon'],
                 { [`${icons['-white']}`]: this.props.showBlending })}
             />
-            <LayerOptionsTooltip
+            {this.props.showBlending &&
+            <LayerBlendingOptionsTooltip
               displayHue={this.props.layer.type === LAYER_TYPES.Heatmap}
               displayOpacity
               hueValue={this.props.layer.hue}
               opacityValue={this.props.layer.opacity}
               onChangeOpacity={opacity => this.onChangeOpacity(opacity)}
               onChangeHue={hue => this.onChangeHue(hue)}
-              showBlending={this.props.showBlending}
               isReverse={this.props.layerIndex < REVERSE_TOOLTIP_ITEMS_MOBILE}
             />
+            }
           </li>}
           <li
             className={LayerListStyles['layer-option-item']}

--- a/app/src/components/Map/LayerOptionsTooltip.jsx
+++ b/app/src/components/Map/LayerOptionsTooltip.jsx
@@ -76,18 +76,18 @@ class LayerOptionsTooltip extends Component {
           { [`${BlendingStyles['-reverse']}`]: this.props.isReverse })
         }
       >
+        {this.props.displayHue && <div>
+          Hue
+          <InputRange
+            classNames={this.hueRangeConfig.classnames}
+            value={this.state.hueRangeValue}
+            maxValue={this.hueRangeConfig.maxValue}
+            minValue={this.hueRangeConfig.minValue}
+            onChange={(component, value) => this.onChangeHue(value)}
+            step={this.hueRangeConfig.step}
+          />
+        </div>}
         {this.props.displayOpacity && <div>
-          {this.props.displayHue && <div>
-            Hue
-            <InputRange
-              classNames={this.hueRangeConfig.classnames}
-              value={this.state.hueRangeValue}
-              maxValue={this.hueRangeConfig.maxValue}
-              minValue={this.hueRangeConfig.minValue}
-              onChange={(component, value) => this.onChangeHue(value)}
-              step={this.hueRangeConfig.step}
-            />
-          </div>}
           Opacity
           <InputRange
             classNames={this.opacityRangeConfig.classnames}

--- a/app/src/components/Map/PinnedTracksItem.jsx
+++ b/app/src/components/Map/PinnedTracksItem.jsx
@@ -28,6 +28,9 @@ class PinnedTracksItem extends Component {
   }
 
   onChangeHue(hue) {
+    if (!this.props.vessel.visible) {
+      this.props.togglePinnedVesselVisibility(this.props.vessel.seriesgroup);
+    }
     this.props.setPinnedVesselHue(this.props.vessel.seriesgroup, hue);
   }
 

--- a/app/src/components/Map/PinnedTracksItem.jsx
+++ b/app/src/components/Map/PinnedTracksItem.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import { REVERSE_TOOLTIP_ITEMS_MOBILE } from 'constants';
-import LayerOptionsTooltip from 'components/Map/LayerOptionsTooltip';
+import LayerBlendingOptionsTooltip from 'components/Map/LayerBlendingOptionsTooltip';
 import pinnedTracksStyles from 'styles/components/map/c-pinned-tracks.scss';
 import icons from 'styles/icons.scss';
 import BlendingIcon from 'babel!svg-react!assets/icons/blending-icon.svg?name=BlendingIcon';
@@ -61,14 +61,14 @@ class PinnedTracksItem extends Component {
                 this.props.onLayerBlendingToggled(this.props.index);
               }}
             />
-            <LayerOptionsTooltip
+            {this.props.showBlending &&
+            <LayerBlendingOptionsTooltip
               displayHue
-              displayOpacity={false}
               hueValue={this.props.vessel.hue}
-              showBlending={this.props.showBlending}
               onChangeHue={hue => this.onChangeHue(hue)}
               isReverse={this.props.index < REVERSE_TOOLTIP_ITEMS_MOBILE}
             />
+            }
           </li>
           <li
             className={pinnedTracksStyles['pinned-item-action-item']}

--- a/app/styles/components/map/c-layer-blending.scss
+++ b/app/styles/components/map/c-layer-blending.scss
@@ -6,10 +6,9 @@
   border: solid 1px rgba($color-3, .4);
   bottom: 27px;
   color: $color-4;
-  display: none;
   font-family: $font-family-1;
   font-size: $font-size-xxs-small;
-  max-height: 0;
+  max-height: none;
   padding: 20px;
   position: absolute;
   right: -30px;
@@ -38,12 +37,6 @@
         top: -7px;
       }
     }
-  }
-
-
-  &.-is-visible {
-    display: block;
-    max-height: none;
   }
 
   :global .blending-range {


### PR DESCRIPTION
Fixes various issues on the blending tooltips. 
- they were appearing empty on pinned tracks and filters
- they were closed automatically when changing the values on layers
- fill style was not closed on tracks, leading to rendering bugs
- pinned track is set to visible automatically when setting hue (same as layers)
- cleanup and small refacto