### PR TITLE
Fix/handle fail headers

### DIFF
--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -37,8 +37,7 @@ export const VESSELS_ENDPOINT_KEYS = [
 export const GUEST_PERMISSION_SET = [
   'seeVesselsLayers',
   'selectVessel',
-  'shareWorkspace',
-  'seeVesselBasicInfo'
+  'shareWorkspace'
 ];
 
 // for now, auth users get no special permissions, everything comes from the API


### PR DESCRIPTION
- remove seeVesselBasicInfo privilege while info endpoint is not able to send partial info
- handle unauthorized layers by omitting a layer when request to the header endpoint fails