### PR TITLE
Fix: toggle style improvement

### DIFF
--- a/app/src/components/Shared/Toggle.jsx
+++ b/app/src/components/Shared/Toggle.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import SwitcherStyles from 'styles/components/shared/c-switcher.scss';
+import SwitcherStyles from 'styles/components/shared/c-toggle.scss';
 import classnames from 'classnames';
 import { hueToRgbString } from 'util/hsvToRgb';
 
@@ -13,15 +13,16 @@ class Toggle extends Component {
 
   render() {
     return (<div
-      className={classnames(SwitcherStyles['c-switcher'], { [SwitcherStyles['-active']]: this.props.on })}
+      className={classnames(SwitcherStyles['c-toggle'], { [SwitcherStyles['-active']]: this.props.on })}
       style={this.props.on ? { background: this.getColor() } : null}
     >
       <input
         type="checkbox"
         onChange={() => this.props.onToggled()}
         checked={this.props.on}
+        readOnly
       />
-      <div className={SwitcherStyles.toggle} />
+      <div className={SwitcherStyles['toggle-ball']} />
     </div>);
   }
 }

--- a/app/styles/components/map/c-layer-library.scss
+++ b/app/styles/components/map/c-layer-library.scss
@@ -51,6 +51,8 @@
       left: 0;
       position: relative;
       width: 100%;
+      margin-top: 5px;
+      pointer-events: none;
     }
   }
 

--- a/app/styles/components/map/c-welcome-modal.scss
+++ b/app/styles/components/map/c-welcome-modal.scss
@@ -10,7 +10,7 @@
   max-height: 50vh;
 
   > .content {
-    overflow: overlay;
+    overflow: auto;
     max-height: 40vh;
     text-align: center;
     padding: 45px 0;

--- a/app/styles/components/shared/c-toggle.scss
+++ b/app/styles/components/shared/c-toggle.scss
@@ -2,21 +2,21 @@
 
 // this component needs crossbrowsing
 
-.c-switcher {
+.c-toggle {
   appearance: none;
   position: relative;
   display: flex;
-  background: linear-gradient(to bottom, $hsla-begin, $hsla-end), linear-gradient(to right, $color-27 50%, currentColor 50%) 0 0, 5px 0;
+  background: $color-27;
   border-radius: 25px;
   cursor: pointer;
-  width: 20px;
+  min-width: 20px;
   height: 10px;
   margin: 0 15px 0 0;
   outline: 0;
   padding: 0 10px 0 0;
 
   &.-active {
-    .toggle {
+    .toggle-ball {
       left: 10px;
     }
   }
@@ -31,14 +31,14 @@
     cursor: pointer;
   }
 
-  .toggle {
+  .toggle-ball {
     position: absolute;
     top: 0;
     left: 0;
     display: inline-block;
     width: 10px;
     height: 10px;
-    background: $color-26 linear-gradient($hsla-end, $hsla-begin);
+    background: $color-4;
     border-radius: 50%;
     transition: .15s ease-in;
     pointer-events: none;


### PR DESCRIPTION
This PR includes following fixes:
- Issue where toggle's width in safari wasn't the minimum needed.
- Removes `overflow: overlay`: _apparently has been deprecated for some time now_.
- Issue where scroll down gradient blocked toggles.