### PR TITLE
Remove temp tileset loading workaround

### DIFF
--- a/app/src/actions/layers.js
+++ b/app/src/actions/layers.js
@@ -168,13 +168,10 @@ export function toggleLayerWorkspacePresence(layerId, forceStatus = null) {
     });
     if (newLayer.type === LAYER_TYPES.Heatmap) {
       if (added === true) {
-        // TODO remove: this is a hack needed because current library endpoint returns a vessel heatmap url that doesnt work
-        const url = (newLayer.url === 'https://api-dot-world-fishing-827.appspot.com/v1/tilesets/801-tileset-nz2') ?
-        'https://api-dot-world-fishing-827.appspot.com/v1/tilesets/849-tileset-tms' :
-        newLayer.url;
+        const url = newLayer.url;
 
         if (newLayer.header === undefined) {
-          loadLayerHeader(newLayer.url, getState().user.token).then((header) => {
+          loadLayerHeader(url, getState().user.token).then((header) => {
             if (header) {
               dispatch(setLayerHeader(layerId, header));
               dispatch(addHeatmapLayerFromLibrary(layerId, url));


### PR DESCRIPTION
Removed a hack to load the latest version of the fishing effort layer.