### PR TITLE
prevents zoom on large spanned custom layers

### DIFF
--- a/app/src/components/Layers/CustomLayerWrapper.js
+++ b/app/src/components/Layers/CustomLayerWrapper.js
@@ -1,10 +1,15 @@
+import { MAX_AUTO_ZOOM_LONGITUDE_SPAN } from 'constants';
+
 export default class CustomLayerWrapper {
   constructor(map, url) {
     this.map = map;
     this.kmlLayer = new google.maps.KmlLayer({
       url,
-      map
+      map,
+      preserveViewport: true
     });
+    this.handleZoomLevel = this.handleZoomLevel.bind(this);
+    google.maps.event.addListener(this.kmlLayer, 'defaultviewport_changed', this.handleZoomLevel);
   }
 
   show() {
@@ -13,5 +18,13 @@ export default class CustomLayerWrapper {
 
   hide() {
     this.kmlLayer.setMap(null);
+  }
+
+  handleZoomLevel() {
+    const bounds = this.kmlLayer.getDefaultViewport();
+    const span = bounds.toSpan().toJSON();
+
+    if (span.lng >= MAX_AUTO_ZOOM_LONGITUDE_SPAN) this.map.setCenter(bounds.getCenter());
+    else this.map.fitBounds(bounds.toJSON());
   }
 }

--- a/app/src/components/Layers/CustomLayerWrapper.js
+++ b/app/src/components/Layers/CustomLayerWrapper.js
@@ -9,7 +9,8 @@ export default class CustomLayerWrapper {
       preserveViewport: true
     });
     this.handleZoomLevel = this.handleZoomLevel.bind(this);
-    google.maps.event.addListener(this.kmlLayer, 'defaultviewport_changed', this.handleZoomLevel);
+
+    this.zoomListener = google.maps.event.addListener(this.kmlLayer, 'defaultviewport_changed', this.handleZoomLevel);
   }
 
   show() {
@@ -26,5 +27,10 @@ export default class CustomLayerWrapper {
 
     if (span.lng >= MAX_AUTO_ZOOM_LONGITUDE_SPAN) this.map.setCenter(bounds.getCenter());
     else this.map.fitBounds(bounds.toJSON());
+  }
+
+  destroy() {
+    google.maps.event.removeListener(this.zoomListener);
+    this.hide();
   }
 }

--- a/app/src/components/Layers/MapLayers.jsx
+++ b/app/src/components/Layers/MapLayers.jsx
@@ -272,9 +272,8 @@ class MapLayers extends Component {
     this.addedLayers[layer.id] = new CustomLayerWrapper(this.map, layer.url);
   }
 
-  removeCustomLayer() {
-    // TODO
-    console.warn('removeCustomLayer: TBD');
+  removeCustomLayer(layer) {
+    this.addedLayers[layer.id].destroy();
   }
 
   /**

--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -22,6 +22,7 @@ export const TIMELINE_MAX_TIME = TIMELINE_STEP * TIMELINE_MAX_STEPS; // six mont
 
 export const MIN_ZOOM_LEVEL = 2;
 export const MAX_ZOOM_LEVEL = 12;
+export const MAX_AUTO_ZOOM_LONGITUDE_SPAN = 200;
 
 export const VESSELS_ENDPOINT_KEYS = [
   'category',


### PR DESCRIPTION
This PR fixes an issue where large layers (global ones specially) were zoomed out and map went gray.