### PR TITLE
Fix: transforms dates to utc

### DIFF
--- a/app/src/actions/timebar.js
+++ b/app/src/actions/timebar.js
@@ -5,8 +5,10 @@ import {
 } from 'actions';
 
 export function loadTimebarChartData(startDate, endDate) {
-  const start = parseInt(startDate.getFullYear(), 10);
-  const end = parseInt(endDate.getFullYear(), 10);
+  let start = new Date(startDate.valueOf() + (startDate.getTimezoneOffset() * 60000));
+  start = parseInt(start.getFullYear(), 10);
+  let end = new Date(endDate.valueOf() + (endDate.getTimezoneOffset() * 60000));
+  end = parseInt(end.getFullYear(), 10);
 
   return (dispatch) => {
     const chartData = [];

--- a/app/src/actions/timebar.js
+++ b/app/src/actions/timebar.js
@@ -5,11 +5,8 @@ import {
 } from 'actions';
 
 export function loadTimebarChartData(startDate, endDate) {
-  let start = new Date(startDate.valueOf() + (startDate.getTimezoneOffset() * 60000));
-  start = parseInt(start.getFullYear(), 10);
-  let end = new Date(endDate.valueOf() + (endDate.getTimezoneOffset() * 60000));
-  end = parseInt(end.getFullYear(), 10);
-
+  const start = parseInt(startDate.getUTCFullYear(), 10);
+  const end = parseInt(endDate.getUTCFullYear(), 10);
   return (dispatch) => {
     const chartData = [];
     for (let i = 0; i <= (end - start); i += 1) {


### PR DESCRIPTION
This PR fixes an issue that ocurred when loading timebar json files from timezones that were still in 2011 at `2012-01-01 UTC` time.