### PR TITLE
Fix/no header styles

### DIFF
--- a/app/src/components/Map.jsx
+++ b/app/src/components/Map.jsx
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import _ from 'lodash';
 import { GoogleMapLoader, GoogleMap } from 'react-google-maps';
-import { MIN_ZOOM_LEVEL, REQUIRE_MAP_LOGIN } from 'constants';
+import { MIN_ZOOM_LEVEL } from 'constants';
 import ControlPanel from 'containers/Map/ControlPanel';
 import Header from 'containers/Header';
 import mapCss from 'styles/components/c-map.scss';
@@ -174,9 +174,7 @@ class Map extends Component {
     const canShareWorkspaces = !this.props.isEmbedded && (this.props.userPermissions.indexOf('shareWorkspace') !== -1);
 
     return (<div className="full-height-container">
-      {(COMPLETE_MAP_RENDER || this.props.isEmbedded) &&
-      <Header isEmbedded={this.props.isEmbedded} />
-      }
+      <Header isEmbedded={this.props.isEmbedded} canShareWorkspaces={canShareWorkspaces} />
       {!this.props.isEmbedded &&
       <div>
         <Modal
@@ -275,8 +273,7 @@ class Map extends Component {
         </div>
         <div
           className={classnames(mapCss['attributions-container'], {
-            [mapCss['-embed']]: this.props.isEmbedded,
-            [mapCss['-no-header']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded)
+            [mapCss['-embed']]: this.props.isEmbedded
           })}
         >
           <span className={mapCss['mobile-map-attributions']}>

--- a/app/src/components/Map.jsx
+++ b/app/src/components/Map.jsx
@@ -237,7 +237,7 @@ class Map extends Component {
         >
           <PromptLayerRemoval />
         </Modal>
-        <ControlPanel />
+        <ControlPanel isEmbedded={this.props.isEmbedded} />
         <ReportPanel />
       </div>
       }
@@ -273,7 +273,12 @@ class Map extends Component {
             <ZoomOutIcon className={classnames(iconStyles.icon, iconStyles['icon-zoom-out'])} />
           </span>
         </div>
-        <div className={classnames(mapCss['attributions-container'], { [mapCss['-embed']]: this.props.isEmbedded })}>
+        <div
+          className={classnames(mapCss['attributions-container'], {
+            [mapCss['-embed']]: this.props.isEmbedded,
+            [mapCss['-no-header']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded)
+          })}
+        >
           <span className={mapCss['mobile-map-attributions']}>
 
             <a

--- a/app/src/components/Map/ControlPanel.jsx
+++ b/app/src/components/Map/ControlPanel.jsx
@@ -194,7 +194,10 @@ class ControlPanel extends Component {
         {(matches) => {
           if (matches) {
             return (
-              <div className={controlPanelStyle.controlpanel} >
+              <div
+                className={classnames(controlPanelStyle.controlpanel,
+                  { [controlPanelStyle['-no-header']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded) })}
+              >
                 <div className={controlPanelStyle['bg-wrapper']} >
                   {this.renderResume()}
                   <VesselInfoPanel />
@@ -212,20 +215,25 @@ class ControlPanel extends Component {
               </div>);
           }
 
-          return (<div className={controlPanelStyle.controlpanel} >
-            {this.renderResume()}
-            <VesselInfoPanel />
-            <Accordion
-              activeItems={6}
-              allowMultiple={false}
-              className={controlPanelStyle['map-options']}
+          return (
+            <div
+              className={classnames(controlPanelStyle.controlpanel, {
+                [controlPanelStyle['-no-header']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded)
+              })}
             >
-              {this.renderSearch()}
-              {this.renderBasemap()}
-              {this.renderLayerPicker()}
-              {this.renderFilters()}
-            </Accordion>
-          </div>);
+              {this.renderResume()}
+              <VesselInfoPanel />
+              <Accordion
+                activeItems={6}
+                allowMultiple={false}
+                className={controlPanelStyle['map-options']}
+              >
+                {this.renderSearch()}
+                {this.renderBasemap()}
+                {this.renderLayerPicker()}
+                {this.renderFilters()}
+              </Accordion>
+            </div>);
         }}
       </MediaQuery>
     );
@@ -243,7 +251,8 @@ ControlPanel.propTypes = {
   hideSearchResults: React.PropTypes.func,
   pinnedVesselEditMode: React.PropTypes.bool,
   layerPanelEditMode: React.PropTypes.bool,
-  timelineInnerExtent: React.PropTypes.array
+  timelineInnerExtent: React.PropTypes.array,
+  isEmbedded: React.PropTypes.bool
 };
 
 export default ControlPanel;

--- a/app/src/components/Map/ControlPanel.jsx
+++ b/app/src/components/Map/ControlPanel.jsx
@@ -226,7 +226,9 @@ class ControlPanel extends Component {
               <Accordion
                 activeItems={6}
                 allowMultiple={false}
-                className={controlPanelStyle['map-options']}
+                className={classnames(controlPanelStyle['map-options'], {
+                  [controlPanelStyle['-no-header']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded)
+                })}
               >
                 {this.renderSearch()}
                 {this.renderBasemap()}

--- a/app/src/components/Map/ControlPanel.jsx
+++ b/app/src/components/Map/ControlPanel.jsx
@@ -194,10 +194,7 @@ class ControlPanel extends Component {
         {(matches) => {
           if (matches) {
             return (
-              <div
-                className={classnames(controlPanelStyle.controlpanel,
-                  { [controlPanelStyle['-no-header']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded) })}
-              >
+              <div className={classnames(controlPanelStyle.controlpanel)}>
                 <div className={controlPanelStyle['bg-wrapper']} >
                   {this.renderResume()}
                   <VesselInfoPanel />
@@ -216,18 +213,14 @@ class ControlPanel extends Component {
           }
 
           return (
-            <div
-              className={classnames(controlPanelStyle.controlpanel, {
-                [controlPanelStyle['-no-header']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded)
-              })}
-            >
+            <div className={controlPanelStyle.controlpanel} >
               {this.renderResume()}
               <VesselInfoPanel />
               <Accordion
                 activeItems={6}
                 allowMultiple={false}
                 className={classnames(controlPanelStyle['map-options'], {
-                  [controlPanelStyle['-no-header']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded)
+                  [controlPanelStyle['-no-footer']]: (!COMPLETE_MAP_RENDER && !this.props.isEmbedded)
                 })}
               >
                 {this.renderSearch()}

--- a/app/src/components/Map/ReportPanel.jsx
+++ b/app/src/components/Map/ReportPanel.jsx
@@ -28,7 +28,11 @@ class ReportPanel extends Component {
     if (this.props.visible === false) return null;
 
     const panelClass = this.state.expanded && window.innerWidth >= 1024 ?
-      classnames(ReportPanelStyles['c-report-panel'], ReportPanelStyles['-minimized']) : ReportPanelStyles['c-report-panel'];
+      classnames(ReportPanelStyles['c-report-panel'], ReportPanelStyles['-minimized'], {
+        [ReportPanelStyles['-no-footer']]: !COMPLETE_MAP_RENDER
+      }) : classnames(ReportPanelStyles['c-report-panel'], {
+        [ReportPanelStyles['-no-footer']]: !COMPLETE_MAP_RENDER
+      });
 
     const containerClass = this.state.expanded ?
       classnames(ReportPanelStyles.container, ReportPanelStyles['-expanded']) : ReportPanelStyles.container;

--- a/app/src/components/Shared/Header.jsx
+++ b/app/src/components/Shared/Header.jsx
@@ -26,34 +26,12 @@ class Header extends Component {
 
   render() {
     const logoUrl = this.props.isEmbedded ? `${MAP_URL}?workspace=${this.props.urlWorkspaceId}` : SITE_URL;
-    let userLinks;
-    if (this.props.loggedUser) {
-      const name = this.props.loggedUser.displayName.split(' ');
-      userLinks = (
-        <li className={styles.dropdown} >
-          <a className={styles['login-a']} >{name[0]}</a>
-          <ul className={styles['dropdown-content']} >
-            <li>
-              <a onClick={this.logout} >
-                Logout
-              </a>
-            </li>
-          </ul>
-        </li>
-      );
-    } else {
-      userLinks = (
-        <li>
-          <a onClick={this.login} >Login</a>
-        </li>
-      );
-    }
 
     const target = this.props.isEmbedded ? '_parent' : '';
 
     return (
       <div>
-        {!this.props.isEmbedded &&
+        {(!this.props.isEmbedded && COMPLETE_MAP_RENDER) &&
         <MenuMobile
           visible={this.state.mobileMenuVisible}
           onClose={this.closeMobileMenu}
@@ -71,7 +49,7 @@ class Header extends Component {
             }
           >
             <div className={styles['contain-nav']} >
-              {!this.props.isEmbedded &&
+              {(!this.props.isEmbedded && COMPLETE_MAP_RENDER) &&
               <img
                 onClick={() => this.setState({ mobileMenuVisible: true })}
                 className={styles['icon-menu-mobile']}
@@ -79,6 +57,7 @@ class Header extends Component {
                 alt="Menu toggle icon"
               />
               }
+              {(this.props.isEmbedded || COMPLETE_MAP_RENDER) &&
               <a
                 target={target}
                 href={logoUrl}
@@ -89,63 +68,12 @@ class Header extends Component {
                   alt="Global Fishing Watch"
                 />
               </a>
-              {!this.props.isEmbedded &&
-              <ShareIcon
-                className={classnames(iconStyles.icon, iconStyles['icon-share'], styles['icon-share'])}
-                onClick={this.props.openShareModal}
-              />}
-              {!this.props.isEmbedded &&
-              <ul className={styles.menu} >
-                <li>
-                  <a className={styles['-active']} href="#" >Map</a>
-                </li>
-                <li className={styles.dropdown} >
-                  <a
-                    className={
-                      /\/articles-publications/.test(location.pathname)
-                        ? classnames(styles['-active'], styles['-no-cursor']) : styles['-no-cursor']
-                    }
-                  >
-                    News
-                  </a>
-                  <ul className={styles['dropdown-content']} >
-                    <li>
-                      <a
-                        href={BLOG_URL}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                      >Blog</a>
-                    </li>
-                    <li><a href={`${SITE_URL}/articles-publications`} >Articles and Publications</a></li>
-                  </ul>
-                </li>
-                <li className={styles.dropdown} >
-                  <a
-                    className={styles['-no-cursor']}
-                  >
-                    How to
-                  </a>
-                  <ul className={styles['dropdown-content']} >
-                    <li><a href={`${SITE_URL}/faq`} >FAQ</a></li>
-                    <li><a href={`${SITE_URL}/tutorials`} >Tutorials</a></li>
-                    <li><a href={`${SITE_URL}/definitions`} >Definitions</a></li>
-                  </ul>
-                </li>
-                <li className={styles.dropdown} >
-                  <a
-                    className={styles['-no-cursor']}
-                  >
-                    About
-                  </a>
-                  <ul className={styles['dropdown-content']} >
-                    <li><a href={`${SITE_URL}/the-project`} >The project</a></li>
-                    <li><a href={`${SITE_URL}/partners`} >Partners</a></li>
-                    <li><a href={`${SITE_URL}/research-program`} >Research program</a></li>
-                    <li><a href={`${SITE_URL}/contact-us`} >Contact us</a></li>
-                  </ul>
-                </li>
-                {userLinks}
-              </ul>
+              }
+              {this.props.canShareWorkspaces &&
+                <ShareIcon
+                  className={classnames(iconStyles.icon, iconStyles['icon-share'], styles['icon-share'])}
+                  onClick={this.props.openShareModal}
+                />
               }
             </div>
           </div>
@@ -163,7 +91,8 @@ Header.propTypes = {
   setSupportModalVisibility: React.PropTypes.func,
   setVisibleMenu: React.PropTypes.func,
   isEmbedded: React.PropTypes.bool,
-  urlWorkspaceId: React.PropTypes.string
+  urlWorkspaceId: React.PropTypes.string,
+  canShareWorkspaces: React.PropTypes.bool
 };
 
 export default Header;

--- a/app/styles/components/c-control_panel.scss
+++ b/app/styles/components/c-control_panel.scss
@@ -221,6 +221,20 @@
     :global .react-sanfona-item-expanded > .react-sanfona-item-body {
       max-width: none;
     }
+
+    &.-no-header {
+
+      :global .react-sanfona-item-body {
+
+        > .react-sanfona-item-body-wrapper {
+          height: calc(100vh - #{$accordion-mobile-height + $timebar-height});
+
+          @media #{$mq-tablet} {
+            height: auto;
+          }
+        }
+      }
+    }
   }
 
   .pinned-item-count {

--- a/app/styles/components/c-control_panel.scss
+++ b/app/styles/components/c-control_panel.scss
@@ -222,12 +222,12 @@
       max-width: none;
     }
 
-    &.-no-header {
+    &.-no-footer {
 
       :global .react-sanfona-item-body {
 
         > .react-sanfona-item-body-wrapper {
-          height: calc(100vh - #{$accordion-mobile-height + $timebar-height});
+          height: calc(100vh - #{$accordion-mobile-height + $header-height-mobile});
 
           @media #{$mq-tablet} {
             height: auto;

--- a/app/styles/components/c-control_panel.scss
+++ b/app/styles/components/c-control_panel.scss
@@ -10,6 +10,10 @@
   width: 100%;
   z-index: 102;
 
+  &.-no-header {
+    top: 0;
+  }
+
   @media #{$mq-tablet} {
     background: transparent;
     height: auto;

--- a/app/styles/components/c-map.scss
+++ b/app/styles/components/c-map.scss
@@ -46,10 +46,6 @@
   &.-embed {
     top: $header-height-mobile;
   }
-
-  &.-no-header {
-    top: $accordion-mobile-height;
-  }
 }
 
 .attributions-container > .mobile-map-attributions {

--- a/app/styles/components/c-map.scss
+++ b/app/styles/components/c-map.scss
@@ -46,6 +46,10 @@
   &.-embed {
     top: $header-height-mobile;
   }
+
+  &.-no-header {
+    top: $accordion-mobile-height;
+  }
 }
 
 .attributions-container > .mobile-map-attributions {

--- a/app/styles/components/map/c-recent-vessels.scss
+++ b/app/styles/components/map/c-recent-vessels.scss
@@ -22,6 +22,7 @@
       left: 0;
       position: relative;
       width: 100%;
+      pointer-events: none;
     }
   }
 

--- a/app/styles/components/map/c-report-panel.scss
+++ b/app/styles/components/map/c-report-panel.scss
@@ -27,6 +27,12 @@
     }
   }
 
+  &.-no-footer {
+    @media #{$mq-mobile-large} {
+      bottom: $timebar-height;
+    }
+  }
+
   > .menu {
     align-items: center;
     background-color: $color-13;

--- a/app/styles/components/map/c-welcome-modal.scss
+++ b/app/styles/components/map/c-welcome-modal.scss
@@ -7,13 +7,20 @@
   justify-content: center;
   flex-direction: column;
   position: relative;
-  max-height: 50vh;
+
+  @media #{$mq-tablet} {
+    max-height: 50vh;
+  }
 
   > .content {
     overflow: auto;
-    max-height: 40vh;
+    max-height: 80vh;
     text-align: center;
     padding: 45px 0;
+
+    @media #{$mq-tablet} {
+      max-height: 40vh;
+    }
 
     h1, h2 {
       font-size: $font-size-x-normal;

--- a/app/styles/components/shared/c-header.scss
+++ b/app/styles/components/shared/c-header.scss
@@ -13,6 +13,7 @@
   .contain-nav {
     align-items: center;
     display: flex;
+    justify-content: flex-end;
     height: $header-height-mobile;
 
     @media #{$mq-tablet} {
@@ -67,6 +68,7 @@
     min-height: 16px;
     min-width: 19px;
     order: 3;
+    cursor: pointer;
 
     @media #{$mq-tablet} {
       display: none;

--- a/app/styles/components/shared/c-modal.scss
+++ b/app/styles/components/shared/c-modal.scss
@@ -55,10 +55,12 @@
 
       .contain-padding {
         padding: 40px 20px 20px;
+        height: 100%;
         overflow-y: auto;
 
         @media #{$mq-tablet} {
           padding: 60px;
+          height: auto;
         }
 
         .modal-title {

--- a/app/styles/components/shared/c-modal.scss
+++ b/app/styles/components/shared/c-modal.scss
@@ -55,7 +55,6 @@
 
       .contain-padding {
         padding: 40px 20px 20px;
-        height: 100%;
         overflow-y: auto;
 
         @media #{$mq-tablet} {


### PR DESCRIPTION
This PR fixes some css styles that were broken when no header/footer was shown. 
It also does the following:

- removes the outer scroll of the welcome modal on desktop.
- removes unused menu. It was rendered twice, and with a display: none.
- adds pointer events null to some fade out scroll thingy.
- adds correct cursor style to mobile share button.
- fixes modal undefined opened prop.

