### PR TITLE
Fixes broken reporting id field lookup.

### DIFF
--- a/app/src/reducers/report.js
+++ b/app/src/reducers/report.js
@@ -25,7 +25,14 @@ export default function (state = initialState, action) {
     case SHOW_POLYGON: {
       const polygonData = action.payload.polygonData;
       const id = polygonData.cartodb_id;
-      const reportingId = (polygonData.reporting_id !== undefined) ? polygonData.reporting_id : polygonData.cartodb_id;
+
+      let reportingId = polygonData.cartodb_id;
+      if (polygonData.reporting_id !== undefined) {
+        reportingId = polygonData.reporting_id;
+      } else if (polygonData.reportingId !== undefined) {
+        reportingId = polygonData.reportingId;
+      }
+
       const name = (polygonData.name !== undefined) ? polygonData.name : polygonData.cartodb_id.toString();
       const isInReport = !!state.polygons.find(polygon => polygon.id === id);
       return Object.assign({}, state, {

--- a/app/src/reducers/report.js
+++ b/app/src/reducers/report.js
@@ -25,7 +25,7 @@ export default function (state = initialState, action) {
     case SHOW_POLYGON: {
       const polygonData = action.payload.polygonData;
       const id = polygonData.cartodb_id;
-      const reportingId = (polygonData.reportingId !== undefined) ? polygonData.reportingId : polygonData.cartodb_id;
+      const reportingId = (polygonData.reporting_id !== undefined) ? polygonData.reporting_id : polygonData.cartodb_id;
       const name = (polygonData.name !== undefined) ? polygonData.name : polygonData.cartodb_id.toString();
       const isInReport = !!state.polygons.find(polygon => polygon.id === id);
       return Object.assign({}, state, {


### PR DESCRIPTION
Seems like cartodb doesn't support uppercase identifiers in certain
fields. When we lookup the `reportingId` field, cartodb always returns
`reportingid` (lowercase i), and thus the app never finds that field,
defaulting to using the `cartodb_id` field instead on report requests.

This commit changes the field lookup to be `reporting_id` instead,
which doesn't have this problem and it also makes it more consistent
with the rest of the identifiers we have on carto.