### PR TITLE
decouple layer id from tileset id

### DIFF
--- a/app/src/actions/heatmap.js
+++ b/app/src/actions/heatmap.js
@@ -57,6 +57,7 @@ export function initHeatmapLayers() {
         heatmapLayers[workspaceLayer.id] = {
           url: workspaceLayer.url,
           tiles: [],
+          tilesetId: workspaceLayer.tilesetId,
           // initially attach which of the temporal extents indices are visible with initial outerExtent
           temporalExtentsLoadedIndices: getTemporalExtentsVisibleIndices(currentOuterExtent, workspaceLayer.header.temporalExtents)
         };
@@ -309,6 +310,7 @@ const _queryHeatmap = (state, tileQuery) => {
     if (queriedTile !== undefined && queriedTile.data !== undefined) {
       layersVessels.push({
         layerId,
+        tilesetId: layer.tilesetId,
         vessels: selectVesselsAt(queriedTile.data, state.map.zoom, tileQuery.worldX, tileQuery.worldY, startIndex, endIndex, currentFlags)
       });
     }
@@ -322,6 +324,7 @@ const _queryHeatmap = (state, tileQuery) => {
   let isMouseCluster;
   let isEmpty;
   let layerId;
+  let tilesetId;
   let seriesUids;
 
   if (layersVesselsResult.length === 0) {
@@ -333,6 +336,7 @@ const _queryHeatmap = (state, tileQuery) => {
     // we can get multiple points with similar series and seriesgroup, in which case
     // we should treat that as a successful vessel query, not a cluster
     layerId = layersVesselsResult[0].layerId;
+    tilesetId = layersVesselsResult[0].tilesetId;
     const vessels = layersVesselsResult[0].vessels;
 
     if (vessels.length === 0) {
@@ -350,7 +354,7 @@ const _queryHeatmap = (state, tileQuery) => {
     }
   }
 
-  return { isEmpty, isCluster, isMouseCluster, seriesUids, layerId };
+  return { isEmpty, isCluster, isMouseCluster, seriesUids, layerId, tilesetId };
 };
 
 export function highlightVesselFromHeatmap(tileQuery, latLng) {
@@ -381,7 +385,7 @@ export function getVesselFromHeatmap(tileQuery, latLng) {
       return;
     }
 
-    const { isEmpty, isCluster, isMouseCluster, layerId, seriesUids } = _queryHeatmap(state, tileQuery);
+    const { isEmpty, isCluster, isMouseCluster, tilesetId, seriesUids } = _queryHeatmap(state, tileQuery);
 
     dispatch(clearVesselInfo());
 
@@ -401,7 +405,7 @@ export function getVesselFromHeatmap(tileQuery, latLng) {
       const seriesgroup = parseInt(seriesUid.split('-')[0], 10);
       const series = parseInt(seriesUid.split('-')[1], 10);
 
-      dispatch(addVessel(layerId, seriesgroup, series));
+      dispatch(addVessel(tilesetId, seriesgroup, series));
     }
   };
 }

--- a/app/src/actions/layers.js
+++ b/app/src/actions/layers.js
@@ -102,9 +102,6 @@ export function initLayers(workspaceLayers, libraryLayers) {
           description: libraryLayer.description || matchedWorkspaceLayer.description,
           reportId: libraryLayer.reportId
         });
-        if (matchedWorkspaceLayer.type === LAYER_TYPES.Heatmap) {
-          matchedWorkspaceLayer.url = libraryLayer.url || matchedWorkspaceLayer.url;
-        }
       } else {
         workspaceLayers.push(Object.assign(libraryLayer, { added: false }));
       }

--- a/app/src/actions/layers.js
+++ b/app/src/actions/layers.js
@@ -82,7 +82,6 @@ function setLayerHeader(layerId, header) {
 export function initLayers(workspaceLayers, libraryLayers) {
   return (dispatch, getState) => {
     const state = getState();
-
     if (state.user.userPermissions !== null && state.user.userPermissions.indexOf('seeVesselsLayers') === -1) {
       workspaceLayers = workspaceLayers.filter(l => l.type !== LAYER_TYPES.Heatmap);
       libraryLayers = libraryLayers.filter(l => l.type !== LAYER_TYPES.Heatmap);
@@ -103,6 +102,9 @@ export function initLayers(workspaceLayers, libraryLayers) {
           description: libraryLayer.description || matchedWorkspaceLayer.description,
           reportId: libraryLayer.reportId
         });
+        if (matchedWorkspaceLayer.type === LAYER_TYPES.Heatmap) {
+          matchedWorkspaceLayer.url = libraryLayer.url || matchedWorkspaceLayer.url;
+        }
       } else {
         workspaceLayers.push(Object.assign(libraryLayer, { added: false }));
       }

--- a/app/src/actions/search.js
+++ b/app/src/actions/search.js
@@ -42,6 +42,8 @@ const loadSearchResults = _.debounce((searchTerm, page, state, dispatch) => {
         return;
       }
 
+      // TODO: Remove in favor of doing a serch per vessel layer
+      result.entries.forEach((entry) => { entry.tilesetId = state.map.tilesetId; });
       dispatch({
         type: SET_SEARCH_RESULTS,
         payload: {

--- a/app/src/actions/workspace.js
+++ b/app/src/actions/workspace.js
@@ -235,6 +235,9 @@ function processLegacyWorkspace(data, dispatch) {
   }));
   layersData.forEach((layer) => {
     layer.id = calculateLayerId(layer);
+    if (layer.type === LAYER_TYPES.Heatmap) {
+      layer.tilesetId = layer.id;
+    }
   });
 
   const layers = layersData.filter(l => l.type !== LAYER_TYPES.VesselTrackAnimation);

--- a/app/src/actions/workspace.js
+++ b/app/src/actions/workspace.js
@@ -226,7 +226,7 @@ function processLegacyWorkspace(data, dispatch) {
     type: SET_BASEMAP, payload: workspace.basemap
   });
 
-  const layersData = workspace.map.animations.map(l => ({
+  const layersData = workspace.map.animations.filter(l => l.args.source.args.url).map(l => ({
     title: l.args.title,
     color: l.args.color,
     visible: l.args.visible,

--- a/app/src/components/Layers/MapLayers.jsx
+++ b/app/src/components/Layers/MapLayers.jsx
@@ -225,7 +225,7 @@ class MapLayers extends Component {
       }
 
       // If the layer is already on the map and its visibility changed, we update it
-      if (this.addedLayers[newLayer.id] && oldLayer.visible !== newLayer.visible) {
+      if (this.addedLayers[newLayer.id] && oldLayer && oldLayer.visible !== newLayer.visible) {
         this.toggleLayerVisibility(newLayer);
         continue;
       }

--- a/app/src/components/Map/RecentVesselsModal.jsx
+++ b/app/src/components/Map/RecentVesselsModal.jsx
@@ -19,7 +19,7 @@ class RecentVesselsModal extends Component {
           <li
             className={classnames(ResultListStyles['result-item'], recentVesselStyles['history-item'])}
             key={i}
-            onClick={() => this.props.drawVessel(entry.layerId, entry.seriesgroup)}
+            onClick={() => this.props.drawVessel(entry.tilesetId, entry.seriesgroup)}
           >
             {entry.pinned === true &&
               <PinIcon

--- a/app/src/components/Map/SearchPanel.jsx
+++ b/app/src/components/Map/SearchPanel.jsx
@@ -64,7 +64,6 @@ class SearchPanel extends Component {
           searchTerm={this.props.searchTerm}
           closeSearch={() => this.closeSearch()}
           vesselInfo={this.props.entries[i]}
-          layerId={this.props.searchLayerId}
         />);
       }
     } else if (this.props.searchTerm.length < SEARCH_QUERY_MINIMUM_LIMIT && this.props.searchTerm.length > 0) {
@@ -142,11 +141,7 @@ SearchPanel.propTypes = {
   /*
    Search term to search for
    */
-  searchTerm: React.PropTypes.string,
-  /*
-   Search layer ID
-   */
-  searchLayerId: React.PropTypes.string
+  searchTerm: React.PropTypes.string
 };
 
 export default SearchPanel;

--- a/app/src/components/Map/SearchResult.jsx
+++ b/app/src/components/Map/SearchResult.jsx
@@ -6,7 +6,7 @@ import ResultListStyles from 'styles/components/shared/c-result-list.scss';
 class SearchResult extends Component {
 
   onDrawVessel() {
-    this.props.drawVessel(this.props.vesselInfo, this.props.layerId);
+    this.props.drawVessel(this.props.vesselInfo);
     this.props.closeSearch();
   }
 
@@ -44,8 +44,7 @@ SearchResult.propTypes = {
   closeSearch: React.PropTypes.func,
   drawVessel: React.PropTypes.func,
   searchTerm: React.PropTypes.string,
-  vesselInfo: React.PropTypes.object,
-  layerId: React.PropTypes.string
+  vesselInfo: React.PropTypes.object
 };
 
 export default SearchResult;

--- a/app/src/containers/Map/RecentVesselsModal.js
+++ b/app/src/containers/Map/RecentVesselsModal.js
@@ -12,9 +12,9 @@ const mapDispatchToProps = dispatch => ({
     dispatch(setRecentVesselsModalVisibility(false));
   },
 
-  drawVessel: (layerId, seriesgroup, series) => {
+  drawVessel: (tilesetId, seriesgroup, series) => {
     dispatch(clearVesselInfo());
-    dispatch(addVessel(layerId, seriesgroup, series, true));
+    dispatch(addVessel(tilesetId, seriesgroup, series, true));
     dispatch(setRecentVesselsModalVisibility(false));
   }
 });

--- a/app/src/containers/Map/SearchResult.js
+++ b/app/src/containers/Map/SearchResult.js
@@ -7,9 +7,9 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  drawVessel: (vesselDetails, layerId) => {
+  drawVessel: (vesselDetails) => {
     dispatch(clearVesselInfo());
-    dispatch(addVessel(layerId, vesselDetails.seriesgroup, null, true, true));
+    dispatch(addVessel(vesselDetails.tilesetId, vesselDetails.seriesgroup, null, true, true));
   }
 });
 

--- a/app/src/reducers/vesselInfo.js
+++ b/app/src/reducers/vesselInfo.js
@@ -35,9 +35,9 @@ export default function (state = initialState, action) {
       const newVessel = {
         seriesgroup: action.payload.seriesgroup,
         series: action.payload.series,
-        tileset: action.payload.layerId,
         visible: false,
         pinned: false,
+        tilesetId: action.payload.tilesetId,
         shownInInfoPanel: false,
         hue: HEATMAP_TRACK_HIGHLIGHT_HUE
       };
@@ -191,7 +191,7 @@ export default function (state = initialState, action) {
         seriesgroup: currentVessel.seriesgroup,
         vesselname: currentVessel.vesselname,
         pinned: currentVessel.pinned,
-        layerId: currentVessel.layerId
+        tilesetId: currentVessel.tilesetId
       });
 
       if (vesselHistoryIndex !== -1) {

--- a/app/src/util/calculateLayerId.js
+++ b/app/src/util/calculateLayerId.js
@@ -6,7 +6,7 @@ export default (layer) => {
     const apiIndirectionUrlRegex = /v(1|2)\/directory\/(\w*)\/source$/g;
     const apiIndirectionUrlMatches = apiIndirectionUrlRegex.exec(layer.url);
     if (apiIndirectionUrlMatches) {
-      return apiIndirectionUrlMatches[1];
+      return apiIndirectionUrlMatches[2];
     }
     const cartoVizzJsonRegex = /\/(\w|-)*\/viz.json$/g;
     const cartoVizzJsonMatches = cartoVizzJsonRegex.exec(layer.url);
@@ -16,7 +16,7 @@ export default (layer) => {
     const fishingEffortUrlRegex = /v(1|2)\/tilesets\/((\w|-)*)$/g;
     const fishingEffortUrlMatches = fishingEffortUrlRegex.exec(layer.url);
     if (fishingEffortUrlMatches) {
-      return fishingEffortUrlMatches[1];
+      return fishingEffortUrlMatches[2];
     }
     // Simply hash the URL
     return `${layer.url.split('').reduce((a, b) => {

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -26,7 +26,8 @@
           "hue": 182,
           "type": "ClusterAnimation",
           "opacity": 1,
-          "id": "849-tileset-tms"
+          "tilesetId": "849-tileset-tms",
+          "id": "fishing"
         },
         {
           "title": "MPA - No Take",


### PR DESCRIPTION
We had an implicit requirement that a fishing layer's id in the workspace had to equal the tileset id. This removes that restrictions, which should help on some scenarios. It also puts us 1 step closer to multi-layer vessel searches.

overall, I feel like the map.tilesetUrl and map.tilesetId states should be deprecated.