### PR TITLE
Multi-layer search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
+- Search vessels across multiple heatmap layers
 - Have map follow the COMPLETE_MAP_RENDER value on embedded mode
- 
+
 ## 2.0.0 RC9
 - Fix regression on heatmap interactivity
 

--- a/app/src/actions/search.js
+++ b/app/src/actions/search.js
@@ -38,8 +38,11 @@ const loadSearchResults = _.debounce((searchTerm, page, state, dispatch) => {
   let searchResultList = [];
   let searchResultCount = 0;
 
-  const searchLayerPromises = state.layers.workspaceLayers
+  const layers = state.layers.workspaceLayers
     .filter(layer => layer.type === LAYER_TYPES.Heatmap)
+    .filter(layer => layer.visible === true);
+
+  const searchLayerPromises = layers
     .map(layer =>
       fetch(`${layer.url}/search/?${queryArgs}`, options)
         .then(response => response.json())

--- a/app/src/actions/vesselInfo.js
+++ b/app/src/actions/vesselInfo.js
@@ -16,6 +16,7 @@ import {
   LOAD_RECENT_VESSEL_HISTORY,
   SET_PINNED_VESSEL_TRACK_VISIBILITY
 } from 'actions';
+import { LAYER_TYPES } from 'constants';
 import { fitTimelineToTrack } from 'actions/filters';
 import { trackSearchResultClicked, trackVesselPointClicked } from 'actions/analytics';
 import {
@@ -59,9 +60,11 @@ function setCurrentVessel(tilesetId, seriesgroup, fromSearch) {
     } else {
       throw new Error('XMLHttpRequest is disabled');
     }
+
+    const searchLayer = state.layers.workspaceLayers.find(layer => layer.type === LAYER_TYPES.Heatmap && layer.tilesetId === tilesetId);
     request.open(
       'GET',
-      `${state.map.tilesetUrl}/sub/seriesgroup=${seriesgroup}/info`,
+      `${searchLayer.url}/sub/seriesgroup=${seriesgroup}/info`,
       true
     );
     if (token) {
@@ -340,7 +343,7 @@ export function togglePinnedVesselVisibility(seriesgroup, forceStatus = null) {
     });
     if (visible === true && currentVessel.track === undefined) {
       dispatch(_getVesselTrack({
-        tilesetId: currentVessel.tileset,
+        tilesetId: currentVessel.tilesetId,
         seriesgroup,
         series: null,
         zoomToBounds: true,

--- a/app/src/actions/workspace.js
+++ b/app/src/actions/workspace.js
@@ -87,7 +87,7 @@ export function saveWorkspace(errorAction) {
     if (shownVesselData !== undefined) {
       shownVessel = {
         seriesgroup: shownVesselData.seriesgroup,
-        tileset: shownVesselData.tileset
+        tilesetId: shownVesselData.tilesetId
       };
       if (shownVesselData.series !== null) {
         shownVessel.series = shownVesselData.series;
@@ -104,7 +104,7 @@ export function saveWorkspace(errorAction) {
         },
         pinnedVessels: state.vesselInfo.vessels.filter(e => e.pinned === true).map(e => ({
           seriesgroup: e.seriesgroup,
-          tileset: e.tileset,
+          tilesetId: e.tilesetId,
           title: e.title,
           hue: e.hue
         })),
@@ -172,7 +172,7 @@ function dispatchActions(workspaceData, dispatch, getState) {
   dispatch(initLayers(workspaceData.layers, state.layerLibrary.layers)).then(() => {
     // we need heatmap layers headers to be loaded before loading track
     if (workspaceData.shownVessel) {
-      dispatch(addVessel(workspaceData.shownVessel.tileset, workspaceData.shownVessel.seriesgroup, workspaceData.shownVessel.series));
+      dispatch(addVessel(workspaceData.shownVessel.tilesetId, workspaceData.shownVessel.seriesgroup, workspaceData.shownVessel.series));
     }
   });
 
@@ -256,7 +256,7 @@ function processLegacyWorkspace(data, dispatch) {
     title: l.title,
     hue: hexToHue(l.color),
     seriesgroup: getSeriesGroupsFromVesselURL(l.url),
-    tileset: getTilesetFromVesselURL(l.url)
+    tilesetId: getTilesetFromVesselURL(l.url)
   }));
 
   let shownVessel = null;
@@ -274,7 +274,7 @@ function processLegacyWorkspace(data, dispatch) {
     shownVessel = {
       series: rawVesselLayer.args.selections.selected.data.series[0],
       seriesgroup: rawVesselLayer.args.selections.selected.data.seriesgroup[0],
-      tileset: getTilesetFromLayerURL(rawVesselLayer.args.selections.selected.data.source[0])
+      tilesetId: getTilesetFromLayerURL(rawVesselLayer.args.selections.selected.data.source[0])
     };
   }
 


### PR DESCRIPTION
Fix one bug, get one awesome feature free!!!

Clarifying: the vessel track rendering based on search results seems to still be coupled to the workspace's "tileset" param. This PR aims at decoupling them, by coupling it to the layer's tilesetId. Add an iteration, and we have multi-layer search.

I actually have NOT tested this with multiple layers, which we should do. But hopefully shouldn't be too much work to get there from these changes.