### PR TITLE
Fix loading of disabled fishing layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Fix issue where fishing layers loaded as invisible would never load when made visible
 - Fallback to canvas when WebGL is not available and display a performance warning
 - Shorter timeline labels for small viewports 
 - Fix date pickers on iOs

--- a/app/src/components/Layers/MapLayers.jsx
+++ b/app/src/components/Layers/MapLayers.jsx
@@ -95,12 +95,7 @@ class MapLayers extends Component {
     // update heatmap layer when:
     // - tiled data changed
     // - selected inner extent changed
-    if (this.props.heatmap !== nextProps.heatmap ||
-      innerExtentChanged) {
-      this.updateHeatmap(nextProps);
-    }
-
-    if (nextProps.flagsLayers !== this.props.flagsLayers) {
+    if (this.props.heatmap !== nextProps.heatmap || innerExtentChanged || nextProps.flagsLayers !== this.props.flagsLayers) {
       this.setHeatmapFlags(nextProps);
       this.updateHeatmap(nextProps);
     }


### PR DESCRIPTION
Fishing layers that have visible: false on the workspace are failling to load if you enable them in the layers panel. This fixes the issue