### PR TITLE
removed webpack absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
+- Fixed loading error when loading map from a custom path, ie not at the root of the website
 - Fix issue where fishing layers loaded as invisible would never load when made visible
 - Load workspace id from legacy structure
 - On embedded mode, open site on new tab
 - Fallback to canvas when WebGL is not available and display a performance warning
-- Shorter timeline labels for small viewports 
+- Shorter timeline labels for small viewports
 - Fix date pickers on iOs
 - Hide site menu on embed mode
 

--- a/app/index.html
+++ b/app/index.html
@@ -12,13 +12,13 @@
   <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick.css" />
   <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick-theme.css" />
 
-  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="manifest" href="/manifest.json">
-  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#2b4f93">
+  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16">
+  <link rel="manifest" href="./manifest.json">
+  <link rel="mask-icon" href="./safari-pinned-tab.svg" color="#2b4f93">
   <!-- this will run the website in "app" mode on iOs, adding a ~15s delay to open the website -->
   <!-- http://stackoverflow.com/questions/13413984/slow-initial-loadingscreen-ios-web-app -->
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
   <!-- http://stackoverflow.com/questions/4687698/mulitple-apple-touch-startup-image-resolutions-for-ios-web-app-esp-for-ipad -->
   <!-- <link rel="apple-touch-startup-image" href=""> -->
 

--- a/app/src/actions/literals.js
+++ b/app/src/actions/literals.js
@@ -2,7 +2,7 @@ import { LOAD_LITERALS } from 'actions';
 
 export function loadLiterals() {
   return (dispatch) => {
-    fetch('/literals.json')
+    fetch('./literals.json')
       .then(res => res.json())
       .then((data) => {
         dispatch({

--- a/app/src/actions/workspace.js
+++ b/app/src/actions/workspace.js
@@ -55,7 +55,7 @@ export function setWorkspaceId(workspaceId) {
  */
 export function updateURL() {
   return (dispatch, getState) => {
-    const newURL = `${window.location.protocol}//${window.location.host}?workspace=${getState().map.workspaceId}`;
+    const newURL = `${window.location.origin}${window.location.pathname.replace(/\/$/g, '')}/?workspace=${getState().map.workspaceId}`;
     window.history.pushState({ path: newURL }, '', newURL);
   };
 }

--- a/app/src/components/Map/BasemapPanel.jsx
+++ b/app/src/components/Map/BasemapPanel.jsx
@@ -26,7 +26,7 @@ class BasemapPanel extends Component {
 
     this.props.basemaps.forEach((basemap) => {
       const imageName = _.camelCase(basemap.title);
-      const urlThumbnail = `/basemaps/${imageName}.png`;
+      const urlThumbnail = `./basemaps/${imageName}.png`;
       const itemLayer = (
         <li
           className={classnames(LayerListStyles['layer-item'],

--- a/app/src/components/Map/Share.jsx
+++ b/app/src/components/Map/Share.jsx
@@ -65,7 +65,7 @@ class Share extends Component {
     if (SHARE_BASE_URL) {
       return SHARE_BASE_URL.replace('{workspace_id}', this.props.workspaceId);
     }
-    return `${location.origin}${location.pathname.replace(/\/$/g, '')}?workspace=${this.props.workspaceId}`;
+    return `${location.origin}${location.pathname.replace(/\/$/g, '')}/?workspace=${this.props.workspaceId}`;
   }
 
   updateEmbedSize(event) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -22,8 +22,7 @@ const webpackConfig = {
 
   output: {
     path: path.join(rootPath, 'dist/'),
-    filename: '[name]-[hash].js',
-    publicPath: '/'
+    filename: '[name]-[hash].js'
   },
 
   plugins: [


### PR DESCRIPTION
This stops forcing the root html file to load the js and css bundles from '/', so they should be loaded with a relative path now.