### PR TITLE
Application loaded on different public path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ On server error, the `/public/500.html` page should be displayed.
 
 Port in which the node server will listen for incoming connections
 
+### PUBLIC_PATH
+
+Server subpath over which the application will be served. May be empty if the application should load through relative urls, or a static path for loading through an absolute url. If not empty, it must start and end with a `/` character (such as `/map/`).
+
 #### GOOGLE_API_KEY
 
 API key for Google Maps

--- a/app/index.html
+++ b/app/index.html
@@ -5,7 +5,7 @@
   <title>Global Fishing Watch</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
-  <script src="https://maps.googleapis.com/maps/api/js?v=3.26&key=<%= htmlWebpackPlugin.options.key %>"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?v=3.26&key=${GOOGLE_API_KEY}"></script>
   <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
   <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css"
         media="all" />

--- a/app/index.html
+++ b/app/index.html
@@ -12,13 +12,13 @@
   <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick.css" />
   <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick-theme.css" />
 
-  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32">
-  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16">
-  <link rel="manifest" href="./manifest.json">
-  <link rel="mask-icon" href="./safari-pinned-tab.svg" color="#2b4f93">
+  <link rel="icon" type="image/png" href="${require('../public/favicon-32x32.png')}" sizes="32x32">
+  <link rel="icon" type="image/png" href="${require('../public/favicon-16x16.png')}" sizes="16x16">
+  <link rel="manifest" href="${require('../public/manifest.json')}">
+  <link rel="mask-icon" href="${require('../public/safari-pinned-tab.svg')}" color="#2b4f93">
   <!-- this will run the website in "app" mode on iOs, adding a ~15s delay to open the website -->
   <!-- http://stackoverflow.com/questions/13413984/slow-initial-loadingscreen-ios-web-app -->
-  <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="${require('../public/apple-touch-icon.png')}">
   <!-- http://stackoverflow.com/questions/4687698/mulitple-apple-touch-startup-image-resolutions-for-ios-web-app-esp-for-ipad -->
   <!-- <link rel="apple-touch-startup-image" href=""> -->
 

--- a/app/src/actions/literals.js
+++ b/app/src/actions/literals.js
@@ -2,7 +2,7 @@ import { LOAD_LITERALS } from 'actions';
 
 export function loadLiterals() {
   return (dispatch) => {
-    fetch('./literals.json')
+    fetch(`${PUBLIC_PATH}literals.json`)
       .then(res => res.json())
       .then((data) => {
         dispatch({

--- a/app/src/components/Map/BasemapPanel.jsx
+++ b/app/src/components/Map/BasemapPanel.jsx
@@ -26,7 +26,7 @@ class BasemapPanel extends Component {
 
     this.props.basemaps.forEach((basemap) => {
       const imageName = _.camelCase(basemap.title);
-      const urlThumbnail = `./basemaps/${imageName}.png`;
+      const urlThumbnail = `${PUBLIC_PATH}basemaps/${imageName}.png`;
       const itemLayer = (
         <li
           className={classnames(LayerListStyles['layer-item'],

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -13,8 +13,7 @@ const rootPath = process.cwd();
 const envVariables = process.env;
 
 const webpackConfig = {
-
-  entry: [
+entry: [
     'whatwg-fetch',
     path.join(rootPath, 'app/src/util/assignPolyfill.js'),
     path.join(rootPath, 'app/src/index.jsx')
@@ -34,13 +33,13 @@ const webpackConfig = {
       template: 'app/index.html',
       inject: 'body',
       filename: 'index.html',
-      key: envVariables.GOOGLE_API_KEY
     }),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new webpack.DefinePlugin({
-      ENVIRONMENT: JSON.stringify(process.env.NODE_ENV || 'development'),
+      GOOGLE_API_KEY: JSON.stringify(envVariables.GOOGLE_API_KEY),
+      ENVIRONMENT: JSON.stringify(envVariables.NODE_ENV || 'development'),
       VERSION: JSON.stringify(packageJSON.version),
       MAP_URL: JSON.stringify(envVariables.MAP_URL),
       V2_API_ENDPOINT: JSON.stringify(envVariables.V2_API_ENDPOINT),
@@ -109,13 +108,13 @@ const webpackConfig = {
       },
       {
         test: /\.html$/,
-        loader: 'html?interpolate=require',
+        loader: 'html?interpolate',
       }
     ]
   },
 
   imageWebpackLoader: {
-    optimizationLevel: (process.env.NODE_ENV === 'development' ? 0 : 7),
+    optimizationLevel: (envVariables.NODE_ENV === 'development' ? 0 : 7),
     bypassOnDebug: true,
     interlaced: false
   },
@@ -125,7 +124,7 @@ const webpackConfig = {
 };
 
 // Environment configuration
-if (process.env.NODE_ENV === 'production') {
+if (envVariables.NODE_ENV === 'production') {
   webpackConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({
     compress: {
       warnings: false,
@@ -135,6 +134,7 @@ if (process.env.NODE_ENV === 'production') {
     },
     comments: false
   }));
+  webpackConfig.devtool = 'source-map';
 } else {
   webpackConfig.devtool = 'eval-source-map';
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -13,7 +13,7 @@ const rootPath = process.cwd();
 const envVariables = process.env;
 
 const webpackConfig = {
-entry: [
+  entry: [
     'whatwg-fetch',
     path.join(rootPath, 'app/src/util/assignPolyfill.js'),
     path.join(rootPath, 'app/src/index.jsx')

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -22,7 +22,8 @@ const webpackConfig = {
 
   output: {
     path: path.join(rootPath, 'dist/'),
-    filename: '[name]-[hash].js'
+    filename: '[name]-[hash].js',
+    publicPath: envVariables.PUBLIC_PATH,
   },
 
   plugins: [
@@ -83,7 +84,7 @@ const webpackConfig = {
         loader: 'babel'
       },
       {
-        test: /\.(jpe?g|png|gif|svg)$/i,
+        test: /\.(jpe?g|png|gif|svg|ico)$/i,
         loaders: [
           'file?hash=sha512&digest=hex&name=[hash].[ext]',
           'image-webpack'
@@ -98,8 +99,17 @@ const webpackConfig = {
         loader: 'style-loader!css-loader!postcss-loader'
       },
       {
+        test: /manifest.json$/,
+        loader: 'file?hash=sha512&digest=hex&name=[hash].[ext]'
+      },
+      {
         test: /\.json$/,
+        exclude: /manifest.json$/,
         loader: 'json-loader'
+      },
+      {
+        test: /\.html$/,
+        loader: 'html?interpolate=require',
       }
     ]
   },

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -38,6 +38,7 @@ entry: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new webpack.DefinePlugin({
+      PUBLIC_PATH: JSON.stringify(envVariables.PUBLIC_PATH || ''),
       GOOGLE_API_KEY: JSON.stringify(envVariables.GOOGLE_API_KEY),
       ENVIRONMENT: JSON.stringify(envVariables.NODE_ENV || 'development'),
       VERSION: JSON.stringify(packageJSON.version),

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "extract-text-webpack-plugin": "^1.0.1",
+    "html-loader": "^0.4.5",
     "html-webpack-plugin": "^2.19.0",
     "image-webpack-loader": "^2.0.0",
     "iso-3166-1-alpha-2": "^1.0.0",


### PR DESCRIPTION
This includes a couple of changes we required for our production release:

* Makes webpack build assets using a public path. This is configurable through a `PUBLIC_PATH` env variable. If no `PUBLIC_PATH` is set up (such as in your heroku environment, or in the local development environment), webpack handles it by making requests to the root.

* Configures `HtmlWebpackPlugin` to load the index template through `html-loader`, instead of the custom built-in, ejs-like loader. This allows us to resolve asset location inside the html template so that webpack can actually resolve to the proper location (including public path configurations and cache busting).

* Exposes the `PUBLIC_PATH` env variable with the `DefinePlugin` so that local programmatic requests (such as the literals and the basemap layer thumbnails) can use the configured public path.

* Adds source maps to the production deploy. We need this to debug these kind of problems in production, and source maps are not loaded until you open the developer toolbar, so this has no performance impact on normal users.