### PR TITLE
Add support for dynamic vessel info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Fix support for multiple fishing event layers
+- Add support for dynamic vessel detail info
+
 ## 2.0.3
 - Replace "CartoDB" with "CARTO"
 

--- a/app/src/actions/vesselInfo.js
+++ b/app/src/actions/vesselInfo.js
@@ -49,6 +49,18 @@ export function loadRecentVesselHistory() {
   };
 }
 
+function showVesselDetails(seriesgroup) {
+  return (dispatch, getState) => {
+    dispatch({
+      type: SHOW_VESSEL_DETAILS,
+      payload: {
+        seriesgroup,
+        layer: 'collect layer with getState here, instead of in view'
+      }
+    });
+  };
+}
+
 function setCurrentVessel(tilesetId, seriesgroup, fromSearch) {
   return (dispatch, getState) => {
     const state = getState();
@@ -84,12 +96,7 @@ function setCurrentVessel(tilesetId, seriesgroup, fromSearch) {
         type: SET_VESSEL_DETAILS,
         payload: data
       });
-      dispatch({
-        type: SHOW_VESSEL_DETAILS,
-        payload: {
-          seriesgroup: data.seriesgroup
-        }
-      });
+      dispatch(showVesselDetails(data.seriesgroup));
 
       if (fromSearch) {
         dispatch(trackSearchResultClicked(tilesetId, seriesgroup));
@@ -365,12 +372,7 @@ export function togglePinnedVesselVisibility(seriesgroup, forceStatus = null) {
 export function showPinnedVesselDetails(seriesgroup) {
   return (dispatch) => {
     dispatch(clearVesselInfo());
-    dispatch({
-      type: SHOW_VESSEL_DETAILS,
-      payload: {
-        seriesgroup
-      }
-    });
+    dispatch(showVesselDetails(seriesgroup));
     dispatch(togglePinnedVesselVisibility(seriesgroup, true));
   };
 }

--- a/app/src/actions/vesselInfo.js
+++ b/app/src/actions/vesselInfo.js
@@ -49,15 +49,13 @@ export function loadRecentVesselHistory() {
   };
 }
 
-function showVesselDetails(seriesgroup) {
-  return (dispatch, getState) => {
-    dispatch({
-      type: SHOW_VESSEL_DETAILS,
-      payload: {
-        seriesgroup,
-        layer: 'collect layer with getState here, instead of in view'
-      }
-    });
+function showVesselDetails(tilesetId, seriesgroup) {
+  return {
+    type: SHOW_VESSEL_DETAILS,
+    payload: {
+      seriesgroup,
+      tilesetId
+    }
   };
 }
 
@@ -96,7 +94,7 @@ function setCurrentVessel(tilesetId, seriesgroup, fromSearch) {
         type: SET_VESSEL_DETAILS,
         payload: data
       });
-      dispatch(showVesselDetails(data.seriesgroup));
+      dispatch(showVesselDetails(tilesetId, seriesgroup));
 
       if (fromSearch) {
         dispatch(trackSearchResultClicked(tilesetId, seriesgroup));
@@ -369,10 +367,10 @@ export function togglePinnedVesselVisibility(seriesgroup, forceStatus = null) {
   };
 }
 
-export function showPinnedVesselDetails(seriesgroup) {
+export function showPinnedVesselDetails(tilesetId, seriesgroup) {
   return (dispatch) => {
     dispatch(clearVesselInfo());
-    dispatch(showVesselDetails(seriesgroup));
+    dispatch(showVesselDetails(tilesetId, seriesgroup));
     dispatch(togglePinnedVesselVisibility(seriesgroup, true));
   };
 }

--- a/app/src/components/Map/PinnedTracksItem.jsx
+++ b/app/src/components/Map/PinnedTracksItem.jsx
@@ -17,7 +17,7 @@ class PinnedTracksItem extends Component {
 
   onVesselLabelClick() {
     if (this.props.pinnedVesselEditMode === false) {
-      this.props.onVesselClicked(this.props.vessel.seriesgroup);
+      this.props.onVesselClicked(this.props.vessel.tilesetId, this.props.vessel.seriesgroup);
     }
   }
 

--- a/app/src/components/Map/VesselInfoPanel.jsx
+++ b/app/src/components/Map/VesselInfoPanel.jsx
@@ -31,7 +31,10 @@ class VesselInfoPanel extends Component {
   }
 
   render() {
-    const vesselInfo = this.props.vessels.find(vessel => vessel.shownInInfoPanel === true);
+    // const vesselInfo = this.props.vessels.find(vessel => vessel.shownInInfoPanel === true);
+    // instead directly use:
+    const vesselInfo = this.props.currentlyShownVessel.vessel;
+
     const status = this.props.infoPanelStatus;
 
     if (status === null && vesselInfo === undefined) {
@@ -49,7 +52,10 @@ class VesselInfoPanel extends Component {
     } else if (this.props.userPermissions !== null && this.props.userPermissions.indexOf('seeVesselBasicInfo') === -1) {
       return null;
     } else if (vesselInfo !== undefined) {
-      const currentLayer = this.props.layers.find(layer => layer.tilesetId === vesselInfo.tilesetId);
+      // const currentLayer = this.props.layers.find(layer => layer.tilesetId === vesselInfo.tilesetId);
+      // instead directly use:
+      const currentLayer = this.props.currentlyShownVessel.layer;
+      // I haven't checked but we could probably go further directly collecting vesselFields in the action, instead of sending the whole layer
       let layerFields;
       if (currentLayer !== undefined && currentLayer.header !== undefined && currentLayer.header.vesselFields !== undefined) {
         layerFields = currentLayer.header.vesselFields;

--- a/app/src/components/Map/VesselInfoPanel.jsx
+++ b/app/src/components/Map/VesselInfoPanel.jsx
@@ -17,46 +17,6 @@ class VesselInfoPanel extends Component {
   constructor(props) {
     super(props);
 
-    // TODO: this is a temporary workaround for the fact that the AIS layer is missing data in the headers.
-    this.fakeVesselInfo = [
-      {
-        id: 'vesselname',
-        display: 'Name',
-        anonymous: true
-      },
-      {
-        id: 'imo',
-        display: 'IMO',
-        anonymous: true
-      },
-      {
-        id: 'mmsi',
-        display: 'MMSI',
-        anonymous: true
-      },
-      {
-        id: 'flag',
-        display: 'Country',
-        kind: 'flag',
-        anonymous: false
-      },
-      {
-        id: 'callsign',
-        display: 'Callsign',
-        anonymous: true
-      },
-      {
-        id: 'rfmo_registry_info',
-        display: 'RFMO',
-        kind: 'list_link',
-        anonymous: true
-      },
-      {
-        id: 'seriesgroup',
-        display: false,
-        anonymous: true
-      }
-    ];
     this.state = {
       isExpanded: true // expanded by default to hide the fact that accordion will remain opened.
       // TODO: close the accordion when the info panel appears.
@@ -90,7 +50,7 @@ class VesselInfoPanel extends Component {
       return null;
     } else if (vesselInfo !== undefined) {
       const currentLayer = this.props.layers.find(layer => layer.tilesetId === vesselInfo.tilesetId);
-      let layerFields = this.fakeVesselInfo;
+      let layerFields;
       if (currentLayer !== undefined && currentLayer.header !== undefined && currentLayer.header.vesselFields !== undefined) {
         layerFields = currentLayer.header.vesselFields;
       }
@@ -105,7 +65,24 @@ class VesselInfoPanel extends Component {
           return;
         }
         switch (field.kind) {
-          case 'list_link':
+          case 'prefixedCSVMultiLink':
+            renderedFieldList.push(<div key={field.id} className={vesselPanelStyles['row-info']} >
+              <span className={vesselPanelStyles.key} >{field.display}</span>
+              <ul className={vesselPanelStyles['link-list']} >
+                <li className={vesselPanelStyles['link-list-item']} >
+                  <a
+                    className={vesselPanelStyles['external-link']}
+                    href={`${field.prefix}${vesselInfo[field.id]}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {vesselInfo[field.id]}
+                  </a>
+                </li>
+              </ul>
+            </div>);
+            break;
+          case 'objectArrayMultiLink':
             linkList = [];
             vesselInfo[field.id].forEach((registry) => {
               linkList.push(<li key={registry.rfmo} className={vesselPanelStyles['link-list-item']} >

--- a/app/src/components/Map/VesselInfoPanel.jsx
+++ b/app/src/components/Map/VesselInfoPanel.jsx
@@ -12,7 +12,7 @@ import iconStyles from 'styles/icons.scss';
 import CloseIcon from 'babel!svg-react!assets/icons/close.svg?name=Icon';
 import PinIcon from 'babel!svg-react!assets/icons/pin-icon.svg?name=PinIcon';
 
-import { VESSEL_INFO_HIDDEN, VESSEL_INFO_LOADING, VESSEL_INFO_LOADED } from 'constants';
+import { VESSEL_INFO_STATUS } from 'constants';
 
 class VesselInfoPanel extends Component {
 
@@ -36,13 +36,13 @@ class VesselInfoPanel extends Component {
     const vesselInfo = this.props.currentlyShownVessel;
     const status = this.props.infoPanelStatus;
 
-    if (status !== VESSEL_INFO_LOADING && !vesselInfo) {
+    if (status !== VESSEL_INFO_STATUS.LOADING && vesselInfo === null) {
       return null;
     }
 
     let vesselInfoContents = null;
 
-    if (status === VESSEL_INFO_LOADING) {
+    if (status === VESSEL_INFO_STATUS.LOADING) {
       vesselInfoContents = (
         <div className={vesselPanelStyles['vessel-metadata']} >
           <div>Loading vessel information...</div>
@@ -50,7 +50,7 @@ class VesselInfoPanel extends Component {
       );
     } else if (this.props.userPermissions !== null && this.props.userPermissions.indexOf('seeVesselBasicInfo') === -1) {
       return null;
-    } else if (status === VESSEL_INFO_LOADED && vesselInfo) {
+    } else if (status === VESSEL_INFO_STATUS.LOADED && vesselInfo) {
       const layerFields = this.props.layerFieldsHeaders;
 
       const canSeeVesselDetails = (this.props.userPermissions !== null && this.props.userPermissions.indexOf('info') !== -1);

--- a/app/src/components/Map/VesselInfoPanel.jsx
+++ b/app/src/components/Map/VesselInfoPanel.jsx
@@ -59,13 +59,16 @@ class VesselInfoPanel extends Component {
 
       const renderedFieldList = [];
 
-      layerFields.filter(field => field.display !== false && (canSeeVesselDetails || !field.anonymous)).forEach((field) => {
+      layerFields.filter(field => field.display !== false && (canSeeVesselDetails || field.anonymous)).forEach((field) => {
         let linkList;
         if (vesselInfo[field.id] === undefined) {
           return;
         }
         switch (field.kind) {
           case 'prefixedCSVMultiLink':
+            if (!vesselInfo[field.id]) {
+              break;
+            }
             renderedFieldList.push(<div key={field.id} className={vesselPanelStyles['row-info']} >
               <span className={vesselPanelStyles.key} >{field.display}</span>
               <ul className={vesselPanelStyles['link-list']} >

--- a/app/src/components/Map/VesselInfoPanel.jsx
+++ b/app/src/components/Map/VesselInfoPanel.jsx
@@ -12,6 +12,8 @@ import iconStyles from 'styles/icons.scss';
 import CloseIcon from 'babel!svg-react!assets/icons/close.svg?name=Icon';
 import PinIcon from 'babel!svg-react!assets/icons/pin-icon.svg?name=PinIcon';
 
+import { VESSEL_INFO_HIDDEN, VESSEL_INFO_LOADING, VESSEL_INFO_LOADED } from 'constants';
+
 class VesselInfoPanel extends Component {
 
   constructor(props) {
@@ -34,13 +36,13 @@ class VesselInfoPanel extends Component {
     const vesselInfo = this.props.currentlyShownVessel;
     const status = this.props.infoPanelStatus;
 
-    if (!status && !vesselInfo) {
+    if (status !== VESSEL_INFO_LOADING && !vesselInfo) {
       return null;
     }
 
     let vesselInfoContents = null;
 
-    if (status.isLoading) {
+    if (status === VESSEL_INFO_LOADING) {
       vesselInfoContents = (
         <div className={vesselPanelStyles['vessel-metadata']} >
           <div>Loading vessel information...</div>
@@ -48,8 +50,8 @@ class VesselInfoPanel extends Component {
       );
     } else if (this.props.userPermissions !== null && this.props.userPermissions.indexOf('seeVesselBasicInfo') === -1) {
       return null;
-    } else if (vesselInfo) {
-      let layerFields = this.props.layerFieldsHeaders;
+    } else if (status === VESSEL_INFO_LOADED && vesselInfo) {
+      const layerFields = this.props.layerFieldsHeaders;
 
       const canSeeVesselDetails = (this.props.userPermissions !== null && this.props.userPermissions.indexOf('info') !== -1);
 
@@ -179,7 +181,7 @@ class VesselInfoPanel extends Component {
 VesselInfoPanel.propTypes = {
   layerFieldsHeaders: PropTypes.array,
   currentlyShownVessel: PropTypes.object,
-  infoPanelStatus: PropTypes.object,
+  infoPanelStatus: PropTypes.number,
   userPermissions: PropTypes.array,
   hide: PropTypes.func,
   onTogglePin: PropTypes.func,

--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -122,9 +122,11 @@ export const REPORT_STATUS = {
   sent: 'sent'
 };
 
-export const VESSEL_INFO_HIDDEN = 1;
-export const VESSEL_INFO_LOADING = 2;
-export const VESSEL_INFO_LOADED = 3;
+export const VESSEL_INFO_STATUS = {
+  HIDDEN: 1,
+  LOADING: 2,
+  LOADED: 3
+};
 
 export const DEFAULT_EMBED_SIZE = 'Small';
 export const EMBED_SIZE_SETTINGS = [

--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -122,6 +122,10 @@ export const REPORT_STATUS = {
   sent: 'sent'
 };
 
+export const VESSEL_INFO_HIDDEN = 1;
+export const VESSEL_INFO_LOADING = 2;
+export const VESSEL_INFO_LOADED = 3;
+
 export const DEFAULT_EMBED_SIZE = 'Small';
 export const EMBED_SIZE_SETTINGS = [
   {

--- a/app/src/containers/Map/PinnedTracksItem.js
+++ b/app/src/containers/Map/PinnedTracksItem.js
@@ -14,9 +14,9 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  onVesselClicked: (seriesgroup) => {
+  onVesselClicked: (tilesetId, seriesgroup) => {
     dispatch(setRecentVesselHistory(seriesgroup));
-    dispatch(showPinnedVesselDetails(seriesgroup));
+    dispatch(showPinnedVesselDetails(tilesetId, seriesgroup));
   },
   onRemoveClicked: (seriesgroup) => {
     dispatch(toggleVesselPin(seriesgroup));

--- a/app/src/containers/Map/VesselInfoPanel.js
+++ b/app/src/containers/Map/VesselInfoPanel.js
@@ -4,6 +4,7 @@ import { clearVesselInfo, toggleActiveVesselPin, setRecentVesselHistory } from '
 import { login } from 'actions/user';
 
 const mapStateToProps = state => ({
+  layers: state.layers.workspaceLayers,
   vessels: state.vesselInfo.vessels,
   infoPanelStatus: state.vesselInfo.infoPanelStatus,
   userPermissions: state.user.userPermissions

--- a/app/src/containers/Map/VesselInfoPanel.js
+++ b/app/src/containers/Map/VesselInfoPanel.js
@@ -4,8 +4,9 @@ import { clearVesselInfo, toggleActiveVesselPin, setRecentVesselHistory } from '
 import { login } from 'actions/user';
 
 const mapStateToProps = state => ({
-  layers: state.layers.workspaceLayers,
-  vessels: state.vesselInfo.vessels,
+  // layers: state.layers.workspaceLayers,
+  // vessels: state.vesselInfo.vessels,
+  currentlyShownVessel: state.vesselInfo.currentlyShownVessel,
   infoPanelStatus: state.vesselInfo.infoPanelStatus,
   userPermissions: state.user.userPermissions
 });

--- a/app/src/containers/Map/VesselInfoPanel.js
+++ b/app/src/containers/Map/VesselInfoPanel.js
@@ -3,13 +3,20 @@ import VesselInfoPanel from 'components/Map/VesselInfoPanel';
 import { clearVesselInfo, toggleActiveVesselPin, setRecentVesselHistory } from 'actions/vesselInfo';
 import { login } from 'actions/user';
 
-const mapStateToProps = state => ({
-  // layers: state.layers.workspaceLayers,
-  // vessels: state.vesselInfo.vessels,
-  currentlyShownVessel: state.vesselInfo.currentlyShownVessel,
-  infoPanelStatus: state.vesselInfo.infoPanelStatus,
-  userPermissions: state.user.userPermissions
-});
+const mapStateToProps = (state) => {
+  const currentlyShownLayer = state.layers.workspaceLayers.find(layer => state.vesselInfo.currentlyShownVessel && layer.tilesetId === state.vesselInfo.currentlyShownVessel.tilesetId);
+
+  let layerFieldsHeaders;
+  if (currentlyShownLayer !== undefined && currentlyShownLayer.header !== undefined && currentlyShownLayer.header.vesselFields !== undefined) {
+    layerFieldsHeaders = currentlyShownLayer.header.vesselFields;
+  }
+  return {
+    currentlyShownVessel: state.vesselInfo.currentlyShownVessel,
+    layerFieldsHeaders,
+    infoPanelStatus: state.vesselInfo.infoPanelStatus,
+    userPermissions: state.user.userPermissions
+  };
+}
 
 const mapDispatchToProps = dispatch => ({
   login: () => {

--- a/app/src/reducers/vesselInfo.js
+++ b/app/src/reducers/vesselInfo.js
@@ -113,7 +113,11 @@ export default function (state = initialState, action) {
 
       return Object.assign({}, state, {
         vessels: [...state.vessels.slice(0, vesselIndex), newVessel, ...state.vessels.slice(vesselIndex + 1)],
-        infoPanelStatus: { isLoaded: true }
+        infoPanelStatus: { isLoaded: true },
+        currentlyShownVessel: {
+          vessel: newVessel,
+          layer: action.payload.layer
+        }
       });
     }
 

--- a/app/src/reducers/vesselInfo.js
+++ b/app/src/reducers/vesselInfo.js
@@ -17,13 +17,14 @@ import {
   LOAD_RECENT_VESSEL_HISTORY,
   SET_PINNED_VESSEL_TRACK_VISIBILITY
 } from 'actions';
-import { HEATMAP_TRACK_HIGHLIGHT_HUE, VESSEL_INFO_HIDDEN, VESSEL_INFO_LOADED, VESSEL_INFO_LOADING } from 'constants';
+import { HEATMAP_TRACK_HIGHLIGHT_HUE, VESSEL_INFO_STATUS } from 'constants';
 
 const initialState = {
   vessels: [],
-  infoPanelStatus: VESSEL_INFO_HIDDEN,
+  infoPanelStatus: VESSEL_INFO_STATUS.HIDDEN,
   pinnedVesselEditMode: false,
-  history: []
+  history: [],
+  currentlyShownVessel: null
 };
 
 export default function (state = initialState, action) {
@@ -43,7 +44,7 @@ export default function (state = initialState, action) {
         hue: HEATMAP_TRACK_HIGHLIGHT_HUE
       };
       return Object.assign({}, state, {
-        infoPanelStatus: VESSEL_INFO_LOADING,
+        infoPanelStatus: VESSEL_INFO_STATUS.LOADING,
         vessels: [...state.vessels, newVessel]
       });
     }
@@ -66,7 +67,7 @@ export default function (state = initialState, action) {
 
       return Object.assign({}, state, {
         vessels: [...state.vessels.slice(0, vesselIndex), newVessel, ...state.vessels.slice(vesselIndex + 1)],
-        infoPanelStatus: VESSEL_INFO_LOADED
+        infoPanelStatus: VESSEL_INFO_STATUS.LOADED
       });
     }
 
@@ -125,7 +126,7 @@ export default function (state = initialState, action) {
 
       return Object.assign({}, state, {
         vessels: [...state.vessels.slice(0, vesselIndex), currentlyShownVessel, ...state.vessels.slice(vesselIndex + 1)],
-        infoPanelStatus: VESSEL_INFO_LOADED,
+        infoPanelStatus: VESSEL_INFO_STATUS.LOADED,
         currentlyShownVessel
       });
     }
@@ -136,7 +137,7 @@ export default function (state = initialState, action) {
       // no vessel currently shown: just reset infoPanelStatus
       if (vesselIndex === -1) {
         return Object.assign({}, state, {
-          infoPanelStatus: VESSEL_INFO_HIDDEN,
+          infoPanelStatus: VESSEL_INFO_STATUS.HIDDEN,
           currentlyShownVessel: null
         });
       }
@@ -149,7 +150,7 @@ export default function (state = initialState, action) {
         currentlyShownVessel.shownInInfoPanel = false;
         return Object.assign({}, state, {
           vessels: [...state.vessels.slice(0, vesselIndex), currentlyShownVessel, ...state.vessels.slice(vesselIndex + 1)],
-          infoPanelStatus: VESSEL_INFO_LOADED,
+          infoPanelStatus: VESSEL_INFO_STATUS.LOADED,
           currentlyShownVessel: null
         });
       }
@@ -157,7 +158,7 @@ export default function (state = initialState, action) {
       // vessel is not pinned: get rid of vessel
       return Object.assign({}, state, {
         vessels: [...state.vessels.slice(0, vesselIndex), ...state.vessels.slice(vesselIndex + 1)],
-        infoPanelStatus: VESSEL_INFO_HIDDEN,
+        infoPanelStatus: VESSEL_INFO_STATUS.HIDDEN,
         currentlyShownVessel: null
       });
     }

--- a/app/styles/components/c-vessel-info-panel.scss
+++ b/app/styles/components/c-vessel-info-panel.scss
@@ -83,11 +83,11 @@
       text-decoration: underline;
     }
 
-    .rfmo-list {
+    .link-list {
       display: flex;
       flex-wrap: wrap;
 
-      > .rfmo-item {
+      > .link-list-item {
         width: calc(50% - 3px);
 
         &:nth-child(2n) {
@@ -95,7 +95,7 @@
         }
       }
 
-      > .rfmo-item > .external-link {
+      > .link-list-item > .external-link {
         margin: 10px 0 0;
       }
     }

--- a/public/workspace_vms.json
+++ b/public/workspace_vms.json
@@ -25,7 +25,7 @@
           "description": "VMS Fishing effort",
           "url": "https://api-dot-world-fishing-827.appspot.com/v2/tilesets/483-indo-public-with-no-info-v2",
           "visible": true,
-          "hue": 182,
+          "color": "#42ec20",
           "type": "ClusterAnimation",
           "opacity": 1,
           "id": "fishing",


### PR DESCRIPTION
Until now, vessel details used a hardcoded strucutre. since we now have multiple layers, each with different vessel info details, we need to rely on each vessel layer header to tell us which field and what type it is.