### PR TITLE
Tracks perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+http://localhost:3000/?workspace=udw-v2-6a974c26-35e6-46e2-9064-15023ca8eed6
+
 # Global Fishing Watch
 
 This repository will host the Global Fishing Watch client application developed by [vizzuality](http://www.vizzuality.com/)

--- a/app/src/actions/helpers/heatmapTileData.js
+++ b/app/src/actions/helpers/heatmapTileData.js
@@ -2,6 +2,7 @@ import PelagosClient from 'lib/pelagosClient';
 import pull from 'lodash/pull';
 import uniq from 'lodash/uniq';
 import sumBy from 'lodash/sumBy';
+import simplify from 'simplify-js';
 
 import {
   PLAYBACK_PRECISION,
@@ -138,6 +139,21 @@ export const addWorldCoordinates = (vectorArray, map) => {
     data.worldY[index] = worldPoint.y;
   }
   return data;
+};
+
+export const simplifyTrack = (data) => {
+  const points = new Array(data.latitude.length);
+  for (let index = 0, length = data.latitude.length; index < length; index++) {
+    points[index] = {
+      x: data.worldX[index],
+      y: data.worldY[index],
+      series: data.series[index],
+      datetime: data.datetime[index],
+      hasFishing: data.hasFishing[index]
+    };
+  }
+  // return points;
+  return simplify(points, 0.05);
 };
 
 const _getZoomFactorRadiusRenderingMode = zoom => ((zoom < VESSELS_HEATMAP_STYLE_ZOOM_THRESHOLD) ? 0.3 : 0.15);

--- a/app/src/actions/vesselInfo.js
+++ b/app/src/actions/vesselInfo.js
@@ -24,7 +24,8 @@ import {
   getCleanVectorArrays,
   groupData,
   addWorldCoordinates,
-  addTracksPointsRenderingData
+  addTracksPointsRenderingData,
+  simplifyTrack
 } from 'actions/helpers/heatmapTileData';
 
 export function setRecentVesselHistory(seriesgroup) {
@@ -173,6 +174,7 @@ function _getVesselTrack({ tilesetId, seriesgroup, series, zoomToBounds, updateT
           payload: {
             seriesgroup,
             seriesGroupData: vectorArray,
+            points: simplifyTrack(vectorArray),
             series: uniq(groupedData.series),
             selectedSeries: series,
             tilesetUrl: state.map.tilesetUrl

--- a/app/src/components/Layers/MapLayers.jsx
+++ b/app/src/components/Layers/MapLayers.jsx
@@ -17,6 +17,7 @@ const getTracks = vessels => vessels
     .filter(vessel => vessel.track && (vessel.visible || vessel.shownInInfoPanel))
     .map(vessel => ({
       data: vessel.track.data,
+      points: vessel.track.points,
       selectedSeries: vessel.track.selectedSeries,
       hue: vessel.hue
     }));

--- a/app/src/components/Layers/TracksLayer.js
+++ b/app/src/components/Layers/TracksLayer.js
@@ -11,6 +11,7 @@ export default class TracksLayerGL {
   constructor() {
     this.stage = new PIXI.Graphics();
     this.stage.nativeLines = true;
+    // this.stage.cacheAsBitmap = true;
   }
 
   clear() {
@@ -23,6 +24,7 @@ export default class TracksLayerGL {
     tracks.forEach((track) => {
       n += this._drawTrack(track.data, track.selectedSeries, track.hue, drawParams, offsets);
     });
+    console.log(n)
   }
 
   /**
@@ -61,9 +63,9 @@ export default class TracksLayerGL {
       }
 
       // TODO temporary fix for track performance: do not display out of inner range tracks
-      if (data.datetime[i] < drawParams.startTimestamp || data.datetime[i] > drawParams.endTimestamp) {
-        continue;
-      }
+      // if (data.datetime[i] < drawParams.startTimestamp || data.datetime[i] > drawParams.endTimestamp) {
+      //   continue;
+      // }
       n++;
 
       let pointWorldX = data.worldX[i];
@@ -94,7 +96,7 @@ export default class TracksLayerGL {
       }
       this.stage.lineTo(x, y);
 
-      // 'lineNative' rendering style fixes various rendering issues, but does not allow
+      // 'nativeLines' rendering style fixes various rendering issues, but does not allow
       // for lines thickness different than 1. We double the line and offset it to give the illusion of
       // a 2px wide line
       if (drawStyle & (TRACK_SEGMENT_TYPES.Highlighted | TRACK_SEGMENT_TYPES.InInnerRange) && newLine !== true) {

--- a/app/src/reducers/vesselInfo.js
+++ b/app/src/reducers/vesselInfo.js
@@ -73,6 +73,7 @@ export default function (state = initialState, action) {
       const newVessel = cloneDeep(state.vessels[vesselIndex]);
       newVessel.track = {
         data: action.payload.seriesGroupData,
+        points: action.payload.points,
         selectedSeries: action.payload.selectedSeries
       };
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-sanfona": "daviferreira/react-sanfona#086ef6dd3db5fa8b6cc357e9d9c580fce4053c17",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
+    "simplify-js": "^1.2.1",
     "webpack-bundle-analyzer": "^2.8.1",
     "whatwg-fetch": "^1.0.0"
   },


### PR DESCRIPTION
Trying to improve track performance by reducing the number of points. 
The number of points can be divided by 3 without any visible impact, and divided by 10 with a barely noticeable impact.
As can be seen below, the algo should preserve fishing points, and currently it doesn't. But, I'm not sure I should keep on improving this, because ideally, this should be done on the backend anyways (ie it doesn't make sense to download the points coordinates while 90% of them would eventually be discarded)

original: 30 000 points

![track-simplify-original](https://user-images.githubusercontent.com/1583415/28269882-d987a524-6b03-11e7-9326-b7a697ee7ad2.png)

tolerance 0.01: 10 000 points

![track-simplify-0 01-3](https://user-images.githubusercontent.com/1583415/28269907-eeefd0ee-6b03-11e7-9703-d8ed3f1f9cb4.png)

tolerance 0.1 : 3 000 points

![track-simplify-0 1-10](https://user-images.githubusercontent.com/1583415/28269922-f958ecb4-6b03-11e7-9ef3-e2791eb91ce9.png)

