### PR TITLE
Update react date picker version

### DIFF
--- a/app/src/components/Map/DatePicker.jsx
+++ b/app/src/components/Map/DatePicker.jsx
@@ -25,7 +25,6 @@ class DatePicker extends Component {
         <ReactDatePicker
           fixedHeight
           showYearDropdown
-          dropdownMode="select"
           readOnly
           dateFormat="DD MMM YYYY"
           selected={moment(this.props.selected)}

--- a/app/styles/components/map/c-datepicker.scss
+++ b/app/styles/components/map/c-datepicker.scss
@@ -1,9 +1,6 @@
 @import '../../settings';
 
 :global .c-datepicker {
-  height: 100%;
-  position: relative;
-
   &::after {
     background-color: rgba($color-3, .4);
     content: '';
@@ -17,6 +14,7 @@
   }
 
   .c-datepicker-title {
+    position: relative !important;
     color: rgba($color-3, .5);
     font-size: $font-size-xs-small;
     font-weight: $font-weight-bold;

--- a/app/styles/components/map/c-datepicker.scss
+++ b/app/styles/components/map/c-datepicker.scss
@@ -14,6 +14,7 @@
   }
 
   .c-datepicker-title {
+    border-right: 1px solid $color-7;
     position: relative;
     padding-bottom: 5px;
     color: rgba($color-3, .5);
@@ -36,6 +37,7 @@
   }
 
   .react-datepicker__input-container {
+    border-right: 1px solid $color-7;
     height: 100%;
   }
 

--- a/app/styles/components/map/c-datepicker.scss
+++ b/app/styles/components/map/c-datepicker.scss
@@ -14,12 +14,11 @@
   }
 
   .c-datepicker-title {
-    position: relative !important;
+    position: relative;
+    padding-bottom: 5px;
     color: rgba($color-3, .5);
     font-size: $font-size-xs-small;
     font-weight: $font-weight-bold;
-    padding-bottom: 20px;
-    position: absolute;
     text-align: center;
     text-transform: uppercase;
     top: 16px;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "promise-polyfill": "^6.0.2",
     "prop-types": "^15.5.10",
     "react-addons-create-fragment": "^15.3.0",
-    "react-datepicker": "^0.46.0",
+    "react-datepicker": "^0.52.0",
     "react-ga": "^2.1.2",
     "react-google-maps": "^4.11.0",
     "react-input-range": "^0.9.3",


### PR DESCRIPTION
The react datepicker was not working due to the transition to preact. 
- [x] Change datepicker version
- [x] Fix styles