### PR TITLE
Draw and edit custom areas

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,7 +5,7 @@
   <title>Global Fishing Watch</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
-  <script src="https://maps.googleapis.com/maps/api/js?v=3.27&key=${GOOGLE_API_KEY}"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?v=3.27&key=${GOOGLE_API_KEY}&libraries=drawing"></script>
   <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
   <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css"
         media="all" />

--- a/app/src/components/Map.jsx
+++ b/app/src/components/Map.jsx
@@ -6,12 +6,13 @@ import classnames from 'classnames';
 import delay from 'lodash/delay';
 import template from 'lodash/template';
 import templateSettings from 'lodash/templateSettings';
-import { GoogleMapLoader, GoogleMap } from 'react-google-maps';
+import { GoogleMapLoader, GoogleMap, DrawingManager } from 'react-google-maps';
 import { MIN_ZOOM_LEVEL } from 'constants';
 import ControlPanel from 'containers/Map/ControlPanel';
 import Header from 'containers/Header';
 import mapCss from 'styles/components/c-map.scss';
 import Timebar from 'containers/Map/Timebar';
+// import DrawArea from 'components/Map/DrawArea';
 import Modal from 'components/Shared/Modal';
 import Share from 'containers/Map/Share';
 import LayerInfo from 'containers/Map/LayerInfo';
@@ -191,6 +192,20 @@ class Map extends Component {
     if (event.target.className.match('js-polygon-report') === null) {
       this.props.clearReportPolygon();
     }
+  }
+
+  handleFinish(event) {
+    console.info(event);
+    // const overlay = event.overlay; // regular Google maps API object
+    // Use react-google-maps instead of the created overlay object
+    // google.maps.event.clearInstanceListeners(overlay);
+    // overlay.setMap(null);
+
+    // Ok, now we can handle the event in a "controlled" way
+    // ex:
+    // let radius = overlay.getRadius();
+    // let center = overlay.getCenter();
+    // this.setState({ area: [ ...this.state.area, overlay]});
   }
 
   render() {
@@ -373,7 +388,25 @@ class Map extends Component {
               onZoomChanged={this.onZoomChanged}
               onDragend={this.onDragEnd}
               onIdle={this.onMapIdle}
-            />
+            >
+              <DrawingManager
+                defaultDrawingMode={google.maps.drawing.OverlayType.POLYGON}
+                onOverlaycomplete={this.handleFinish}
+                defaultOptions={{
+                  drawingControl: false,
+                  polygonOptions: {
+                    fillColor: '#174084',
+                    strokeColor: '#174084',
+                    fillOpacity: 0.5,
+                    strokeWeight: 3,
+                    clickable: false,
+                    editable: true,
+                    zIndex: 1
+                  }
+                }}
+              />
+              {/* <DrawArea polygonType={google.maps.drawing.OverlayType.POLYGON} /> */}
+            </GoogleMap>
           }
         />
       </div>

--- a/app/src/components/Map/DrawArea.jsx
+++ b/app/src/components/Map/DrawArea.jsx
@@ -1,0 +1,38 @@
+import React, { Component } from 'preact';
+import PropTypes from 'prop-types';
+import { DrawingManager } from 'react-google-maps';
+
+class DrawArea extends Component {
+  constructor(props) {
+    super(props);
+    this.defaults = {
+      area: null
+    };
+  }
+
+  render() {
+    return (
+      <DrawingManager
+        defaultDrawingMode={this.props.polygonType}
+        defaultOptions={{
+          drawingControl: false,
+          polygonOptions: {
+            fillColor: '#174084',
+            strokeColor: '#174084',
+            fillOpacity: 0.5,
+            strokeWeight: 3,
+            clickable: false,
+            editable: false,
+            zIndex: 1
+          }
+        }}
+      />
+    );
+  }
+}
+
+DrawArea.propTypes = {
+  polygonType: PropTypes.object
+};
+
+export default DrawArea;


### PR DESCRIPTION
- [ ] Update version of react-google-maps
- [x] Draw a polygon and save it to the store
- [x] Show the stored polygon in the map
- [ ] Edit the polygon
- [ ] Add a name to the area store
- [ ] Add tooltip for create, edit, delete polygon
- [ ] Add UI to enter the area drawing