### PR TITLE
Prevent unecessary cloning of vessel tracks on vessel edits

### DIFF
--- a/app/src/reducers/vesselInfo.js
+++ b/app/src/reducers/vesselInfo.js
@@ -1,4 +1,3 @@
-import cloneDeep from 'lodash/cloneDeep';
 import find from 'lodash/find';
 import getVesselName from 'util/getVesselName';
 import { HEATMAP_TRACK_HIGHLIGHT_HUE } from 'config';
@@ -68,7 +67,7 @@ export default function (state = initialState, action) {
 
     case SET_VESSEL_TRACK: {
       const vesselIndex = state.vessels.findIndex(vessel => vessel.seriesgroup === action.payload.seriesgroup);
-      const newVessel = cloneDeep(state.vessels[vesselIndex]);
+      const newVessel = Object.assign({}, state.vessels[vesselIndex]);
       newVessel.track = {
         data: action.payload.data,
         selectedSeries: action.payload.selectedSeries
@@ -91,7 +90,7 @@ export default function (state = initialState, action) {
 
         let currentlyShownVessel = state.currentlyShownVessel;
         if (newVessel.seriesgroup === currentlyShownVessel.seriesgroup && newVessel.tilesetId === currentlyShownVessel.tilesetId) {
-          currentlyShownVessel = cloneDeep(currentlyShownVessel);
+          currentlyShownVessel = Object.assign({}, currentlyShownVessel);
           currentlyShownVessel.pinned = true;
         }
 
@@ -116,7 +115,7 @@ export default function (state = initialState, action) {
 
     case SHOW_VESSEL_DETAILS: {
       const vesselIndex = state.vessels.findIndex(vessel => vessel.seriesgroup === action.payload.seriesgroup);
-      const currentlyShownVessel = cloneDeep(state.vessels[vesselIndex]);
+      const currentlyShownVessel = Object.assign({}, state.vessels[vesselIndex]);
       currentlyShownVessel.shownInInfoPanel = true;
 
       return Object.assign({}, state, {
@@ -141,7 +140,7 @@ export default function (state = initialState, action) {
 
       // vessel is pinned: set info to shownInInfoPanel = false
       if (currentlyShownVessel.pinned === true) {
-        currentlyShownVessel = cloneDeep(currentlyShownVessel);
+        currentlyShownVessel = Object.assign({}, currentlyShownVessel);
         currentlyShownVessel.shownInInfoPanel = false;
         return Object.assign({}, state, {
           vessels: [...state.vessels.slice(0, vesselIndex), currentlyShownVessel, ...state.vessels.slice(vesselIndex + 1)],
@@ -167,7 +166,7 @@ export default function (state = initialState, action) {
     }
     case TOGGLE_VESSEL_PIN: {
       const vesselIndex = action.payload.vesselIndex;
-      const newVessel = cloneDeep(state.vessels[vesselIndex]);
+      const newVessel = Object.assign({}, state.vessels[vesselIndex]);
       newVessel.pinned = action.payload.pinned;
       newVessel.visible = action.payload.visible;
 
@@ -177,7 +176,7 @@ export default function (state = initialState, action) {
         newVessel.seriesgroup === state.currentlyShownVessel.seriesgroup &&
         newVessel.tilesetId === state.currentlyShownVessel.tilesetId
       ) {
-        currentlyShownVessel = cloneDeep(state.currentlyShownVessel);
+        currentlyShownVessel = Object.assign({}, state.currentlyShownVessel);
         currentlyShownVessel.pinned = action.payload.pinned;
       }
 
@@ -190,7 +189,7 @@ export default function (state = initialState, action) {
     }
     case SET_PINNED_VESSEL_HUE: {
       const vesselIndex = state.vessels.findIndex(vessel => vessel.seriesgroup === action.payload.seriesgroup);
-      const newVessel = cloneDeep(state.vessels[vesselIndex]);
+      const newVessel = Object.assign({}, state.vessels[vesselIndex]);
       newVessel.hue = action.payload.hue;
 
       return Object.assign({}, state, {
@@ -199,7 +198,7 @@ export default function (state = initialState, action) {
     }
     case SET_PINNED_VESSEL_TRACK_VISIBILITY: {
       const vesselIndex = state.vessels.findIndex(vessel => vessel.seriesgroup === action.payload.seriesgroup);
-      const newVessel = cloneDeep(state.vessels[vesselIndex]);
+      const newVessel = Object.assign({}, state.vessels[vesselIndex]);
       newVessel.visible = action.payload.visible;
 
       return Object.assign({}, state, {
@@ -222,7 +221,7 @@ export default function (state = initialState, action) {
       });
 
       if (newState.pinnedVesselEditMode === false) {
-        newState.vessels = cloneDeep(state.vessels);
+        newState.vessels = Object.assign({}, state.vessels);
 
         newState.vessels.forEach((vesselDetail) => {
           if (vesselDetail.title.trim() === '') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1763,6 +1763,11 @@
         }
       }
     },
+    "chain-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+    },
     "chalk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
@@ -3157,6 +3162,11 @@
           "dev": true
         }
       }
+    },
+    "dom-helpers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
+      "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -9665,6 +9675,19 @@
         "prop-types": "15.5.10"
       }
     },
+    "react-transition-group": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.0.tgz",
+      "integrity": "sha1-eTv4yxW/6RsxAbJLzhwdKJFllXU=",
+      "requires": {
+        "chain-function": "1.0.0",
+        "classnames": "2.2.5",
+        "dom-helpers": "3.2.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.5.10",
+        "warning": "3.0.0"
+      }
+    },
     "read-all-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
@@ -11886,6 +11909,14 @@
       "dev": true,
       "requires": {
         "wrap-fn": "0.1.5"
+      }
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "1.3.1"
       }
     },
     "watchpack": {


### PR DESCRIPTION
We are doing deep cloning way more often than needed. For example, pinning/unpinning a vessel can take from 0.5 to a couple seconds because of it.

Silly approach (implemented here): replace all cloneDeep calls with plain clone calls. Risky but it seems to work, as I think we never really compare the track array itself, only the vessel object

Pro approach (maybe for later): keep tracks separated from vessel details in the reducer, and use an id for cross-access. 

thoughts?