### PR TITLE
How do we store colors in app state?

### DIFF
--- a/app/src/config.js
+++ b/app/src/config.js
@@ -79,7 +79,8 @@ export const COLORS = {
   yellow: '#FBFF8B',
   lightBlue: '#67FBFE',
   purple: '#7D84FA',
-  orange: '#CC4E4E',
+  red: '#CC4E4E',
+  orange: '#EC6C33',
   pink: '#CC68C4'
 };
 
@@ -88,7 +89,8 @@ export const COLOR_HUES = {
   yellow: 60,
   lightBlue: 182,
   purple: 236,
-  orange: 0,
+  red: 0,
+  orange: 36,
   pink: 305
 };
 

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -43,7 +43,7 @@
           "description": "Marine protected areas - Restricted Use. Click <a href='/definitions/map-restricted-use' target='_blank'>here</a> to know more",
           "url": "https://cartodb.skytruth.org/user/production/api/v2/viz/f65c6e80-8983-11e6-bd2f-0242ac110006/viz.json",
           "visible": true,
-          "hue": 29,
+          "hue": 36,
           "type": "CartoDBAnimation",
           "opacity": 1,
           "id": "mparu"


### PR DESCRIPTION
This is a quick hack so that the MPARU color is the same as the one used in the Carto layer:

![screen shot 2017-09-21 at 16 41 12](https://user-images.githubusercontent.com/1583415/30702196-9299c382-9eec-11e7-82ef-b306c88a6f5a.png)

The way we deal with colors in the app state seems pretty fragile to me. How do you feel about removing hue (legacy from old UI) and named colors everywhere and unify using only hex colors strings?
(we'd only need some mechanism to convert hues to colors from a loaded workspace)