### PR TITLE
Refacto filters modal

### DIFF
--- a/app/src/actions/workspace.js
+++ b/app/src/actions/workspace.js
@@ -17,7 +17,7 @@ import { SET_BASEMAP } from 'basemap/basemapActions';
 import { initLayers } from 'layers/layersActions';
 import { saveAreaOfInterest } from 'areasOfInterest/areasOfInterestActions';
 import { saveFilterGroup } from 'filters/filterGroupsActions';
-import { setFlagFilters, setOuterTimelineDates, SET_INNER_TIMELINE_DATES_FROM_WORKSPACE, setSpeed } from 'filters/filtersActions';
+import { setOuterTimelineDates, SET_INNER_TIMELINE_DATES_FROM_WORKSPACE, setSpeed } from 'filters/filtersActions';
 import { setPinnedVessels, addVessel } from 'actions/vesselInfo';
 import { loadRecentVesselsList } from 'recentVessels/recentVesselsActions';
 import calculateLayerId from 'util/calculateLayerId';
@@ -195,8 +195,6 @@ function dispatchActions(workspaceData, dispatch, getState) {
 
     dispatch(setPinnedVessels(workspaceData.pinnedVessels));
   });
-
-  dispatch(setFlagFilters(workspaceData.filters));
 
   dispatch(loadRecentVesselsList());
 

--- a/app/src/components/Layers/HeatmapLayer.js
+++ b/app/src/components/Layers/HeatmapLayer.js
@@ -51,7 +51,10 @@ export default class HeatmapLayer {
   render(tiles, startIndex, endIndex, offsets) {
 
     const allHuesToRender = (this.filters !== undefined && this.filters.length)
-      ? this.filters.map(f => f.hue.toString())
+      ? this.filters
+        // pass is set to true by filterGroupActions when none of the filters fields in the filter group is supported by the layer headers
+        .filter(f => f.pass !== true)
+        .map(f => f.hue.toString())
       : [this.defaultHue.toString()];
     const currentlyUsedHues = Object.keys(this.subLayers);
 
@@ -72,6 +75,8 @@ export default class HeatmapLayer {
       }
       this.subLayers[hue].spritesProps = [];
     }
+
+    if (!allHuesToRender.length) return;
 
     tiles.forEach((tile) => {
       this._setSubLayersSpritePropsForTile({

--- a/app/src/constants.js
+++ b/app/src/constants.js
@@ -1,3 +1,5 @@
+import getFlagFilterGroupValues from 'util/getFlagFilterGroupValues';
+
 export const CONTROL_PANEL_MENUS = {
   AREAS: 'AREAS',
   FILTERS: 'FILTERS',
@@ -559,3 +561,5 @@ export const FLAGS_SHORTCODES = {
   zm: [127487, 127474],
   zw: [127487, 127484]
 };
+
+export const FLAG_FILTER_GROUP_VALUES = getFlagFilterGroupValues();

--- a/app/src/filters/components/FilterGroupForm.jsx
+++ b/app/src/filters/components/FilterGroupForm.jsx
@@ -1,155 +1,33 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import _includes from 'lodash/includes';
-import _pullAllWith from 'lodash/pullAllWith';
-import _uniqBy from 'lodash/uniqBy';
 import classnames from 'classnames';
-import InfoIcon from '-!babel-loader!svg-react-loader!assets/icons/info.svg?name=InfoIcon';
+import platform from 'platform';
 import ColorPicker from 'components/Shared/ColorPicker';
+import Checkbox from 'components/Shared/Checkbox';
 import ModalStyles from 'styles/components/map/modal.scss';
 import ButtonStyles from 'styles/components/button.scss';
 import ItemList from 'styles/components/map/item-list.scss';
 import IconStyles from 'styles/icons.scss';
-import selectorStyles from 'styles/components/shared/selector.scss';
-import Checkbox from 'components/Shared/Checkbox';
-import getCountryOptions from 'util/getCountryOptions';
-import { FLAGS } from 'constants';
-import { COLORS } from 'config';
-import { getCountry } from 'iso-3166-1-alpha-2';
+import SelectorStyles from 'styles/components/shared/selector.scss';
+import InfoIcon from '-!babel-loader!svg-react-loader!assets/icons/info.svg?name=InfoIcon';
 
 class FilterGroupForm extends Component {
-  constructor(props) {
-    super(props);
 
-    this.onColorChange = this.onColorChange.bind(this);
-    this.onNameChange = this.onNameChange.bind(this);
-    this.onPressSave = this.onPressSave.bind(this);
-
-    const checkedLayers = {};
-    props.layers.forEach((layer) => {
-      checkedLayers[layer.id] = layer.visible;
-    });
-
-    const filterGroup = Object.assign({}, {
-      checkedLayers,
-      color: Object.keys(COLORS)[props.defaultColorIndex],
-      label: '',
-      visible: true,
-      filterValues: {}
-    }, props.filterGroup);
-
-    this.state = { filterGroup };
-  }
-
-  onLayerChecked(layerId) {
-    const filterGroup = this.state.filterGroup;
-    filterGroup.checkedLayers[layerId] = !filterGroup.checkedLayers[layerId];
-
-    this.setState({ filterGroup });
-  }
-
-  onColorChange(color) {
-    const filterGroup = this.state.filterGroup;
-    filterGroup.color = color;
-    this.setState({ filterGroup });
-  }
-
-  onNameChange(event) {
-    const filterGroup = this.state.filterGroup;
-    filterGroup.label = event.target.value;
-    this.setState({ filterGroup });
-  }
-
-  onFilterValueChange(name, value) {
-    const previouslyGeneratedName = this.genFilterName();
-    let filterGroup = Object.assign(this.state.filterGroup);
-    const filterGroupLabel = filterGroup.label;
-    const shouldUpdateGeneratedName = filterGroupLabel === '' || previouslyGeneratedName === filterGroupLabel;
-    if (value === '') {
-      delete filterGroup.filterValues[name];
-    } else {
-      filterGroup.filterValues[name] = parseInt(value, 10);
+  componentWillReceiveProps(nextProps) {
+    // if defaultLabel generated in container changed,
+    // and if user did not changed from the default label (label is the same as the previously generated label)
+    // force trigger a label change with the generated name
+    if (this.props.defaultLabel !== nextProps.defaultLabel &&
+        this.props.label === this.props.defaultLabel) {
+      this.props.onLabelChanged(nextProps.defaultLabel);
     }
-    if (shouldUpdateGeneratedName) {
-      filterGroup = Object.assign(filterGroup, { label: this.genFilterName() });
-    }
-    this.setState({ filterGroup });
-  }
-
-  onPressSave() {
-    this.props.saveFilterGroup(this.state.filterGroup, this.props.editFilterGroupIndex);
-  }
-
-  genFilterName() {
-    const checkedLayersId = Object.keys(this.state.filterGroup.checkedLayers)
-      .filter(elem => this.state.filterGroup.checkedLayers[elem] === true);
-
-    const layersToFilter = this.props.layers.filter(layer =>
-      _includes(checkedLayersId, layer.id) && layer.header.filters
-    );
-
-    const filtersFromLayers = layersToFilter.map(layer => layer.header.filters);
-    const flattenedFilters = [].concat(...filtersFromLayers);
-    const uniqueFiltersFromLayers = [];
-
-    // obscure logic that looks for filters with the same id and merges their values into a single filter
-    while (flattenedFilters.length > 0) {
-      const key = flattenedFilters[0];
-      const matches = flattenedFilters.filter(elem => elem.id === key.id);
-      const values = [];
-
-      matches.forEach((match) => {
-        if (match.values) values.push(...match.values);
-      });
-      const uniqValues = _uniqBy(values, e => e.id);
-
-      key.values = uniqValues;
-      uniqueFiltersFromLayers.push(key);
-
-      _pullAllWith(flattenedFilters, [key], (a, b) => (a.id === b.id));
-    }
-
-    // const uniqueFiltersFromLayers = _uniqBy(flattenedFilters, e => e.label);
-
-    const selectedFilters = uniqueFiltersFromLayers.filter(filter => filter.field in this.state.filterGroup.filterValues);
-
-    const selectedFilterValues = selectedFilters.map((filter) => {
-      let value;
-
-      if (filter.field === 'category' && filter.useDefaultValues === true) {
-        value = getCountry(FLAGS[this.state.filterGroup.filterValues[filter.field]]);
-      } else {
-        const filterSetting = filter.values.find(elem => elem.id === parseInt(this.state.filterGroup.filterValues[filter.field], 10));
-        value = filterSetting ? filterSetting.label : '';
-      }
-
-      return value;
-    });
-    return selectedFilterValues.join(' ');
   }
 
   onClickInfo(layer) {
-    const modalParams = {
+    this.props.openLayerInfoModal({
       open: true,
       info: layer
-    };
-
-    this.props.openLayerInfoModal(modalParams);
-  }
-
-  getOptions(filter) {
-    const compareById = (a, b) => (a.id < b.id ? -1 : 1);
-    let options = [<option key={filter.id} value="" >{filter.label}</option >];
-    if (filter.values) {
-      options = options.concat(
-        filter.values.sort(compareById).map(option => (
-          <option key={option.id} value={option.id} >{option.label}</option >
-        ))
-      );
-    } else {
-      console.warn('No values for filter', filter);
-    }
-    return options;
+    });
   }
 
   renderLayersList() {
@@ -164,8 +42,8 @@ class FilterGroupForm extends Component {
           id={`${layer.id}${layer.title}`}
           label={layer.title}
           labelClassNames={ModalStyles.itemTitle}
-          callback={() => this.onLayerChecked(layer.id)}
-          checked={this.state.filterGroup.checkedLayers[layer.id]}
+          callback={() => this.props.onLayerChecked(layer.id)}
+          checked={layer.filterActivated}
         />
         <ul className={classnames([ItemList.itemOptionList, ItemList._inlineList])} >
           <li
@@ -179,129 +57,119 @@ class FilterGroupForm extends Component {
     ));
   }
 
-  renderFilterList() {
-    const checkedLayersId = Object.keys(this.state.filterGroup.checkedLayers)
-      .filter(elem => this.state.filterGroup.checkedLayers[elem] === true);
+  renderFilterOptions(filter) {
+    let options = [<option key={filter.id} value="" >{filter.label}</option>];
 
-    const layersToFilter = this.props.layers.filter(layer =>
-      _includes(checkedLayersId, layer.id) && layer.header.filters
-    );
+    const supportsEmojiFlags =
+      ['iOS', 'OS X'].indexOf(platform.os.family) > -1 ||
+      platform.os.toString().match('Windows 10');
 
-    const filtersFromLayers = layersToFilter.map(layer => layer.header.filters);
-    const flattenedFilters = [].concat(...filtersFromLayers);
-    const uniqueFiltersFromLayers = [];
-
-    // obscure logic that looks for filters with the same id and merges their values into a single filter
-    while (flattenedFilters.length > 0) {
-      const key = flattenedFilters[0];
-      const matches = flattenedFilters.filter(elem => elem.id === key.id);
-      const values = [];
-
-      matches.forEach((match) => {
-        if (match.values) values.push(...match.values);
-      });
-      const uniqValues = _uniqBy(values, e => e.id);
-
-      key.values = uniqValues;
-      uniqueFiltersFromLayers.push(key);
-
-      _pullAllWith(flattenedFilters, [key], (a, b) => (a.id === b.id));
+    if (filter.values) {
+      options = options.concat(
+        filter.values.map((option) => {
+          const label = (supportsEmojiFlags && option.icon !== undefined) ? `${option.label} ${option.icon}` : option.label;
+          return <option key={option.id} value={option.id} >{label}</option>;
+        })
+      );
     }
 
-    const filterInputs = uniqueFiltersFromLayers.map((filter, index) => (
-      <div key={index} className={classnames(selectorStyles.selector, selectorStyles._big)} >
+    return options;
+  }
+
+  renderFiltersList() {
+    return this.props.filters.map((filter, index) => (
+      <div key={index} className={classnames(SelectorStyles.selector, SelectorStyles._big)} >
         <select
           key={index}
           name={filter.label}
-          onChange={e => this.onFilterValueChange(filter.field, e.target.value)}
-          value={this.state.filterGroup.filterValues[filter.field]}
+          value={this.props.currentlyEditedFilterGroup.filterValues[filter.id]}
+          onChange={e => this.props.onFilterValueChanged(filter.id, e.target.value)}
         >
-          {(filter.field === 'category' || filter.field === 'flag_id') && filter.useDefaultValues === true ?
-            getCountryOptions() : this.getOptions(filter)}
-        </select >
-      </div >
+          {this.renderFilterOptions(filter)}
+        </select>
+      </div>
     ));
-
-    return (
-      <div >
-        {filterInputs}
-      </div >
-    );
   }
+
 
   render() {
     const layersList = this.renderLayersList();
-
-    const filterGroup = this.state.filterGroup;
-    const anyLayerChecked = Object.keys(filterGroup.checkedLayers).some(key => filterGroup.checkedLayers[key] === true);
-    const anyFilterSelected = Object.keys(filterGroup.filterValues).length > 0;
-    const disableSave = anyLayerChecked === false || anyFilterSelected === false;
-
+    const filtersList = this.renderFiltersList();
     return (
-      <div >
+      <div>
         <h3 className={ModalStyles.title}>Filter Group</h3>
-        <div className={ModalStyles.optionsContainer} >
-          <div className={ModalStyles.column} >
-            <div className={ModalStyles.wrapper} >
-              <div className={ModalStyles.sectionTitle} >
+        <div className={ModalStyles.optionsContainer}>
+          <div className={ModalStyles.column}>
+            <div className={ModalStyles.wrapper}>
+              <div className={ModalStyles.sectionTitle}>
                 Select a Fishing Layer:
-              </div >
-              <div className={ItemList.wrapper} >
-                <ul >
+              </div>
+              <div className={ItemList.wrapper}>
+                <ul>
                   {layersList}
-                </ul >
-              </div >
-            </div >
-            <div className={ModalStyles.wrapper} >
-              <ColorPicker id={'filter-color'} color={this.state.filterGroup.color} onColorChange={this.onColorChange} />
-            </div >
-          </div >
-          <div className={ModalStyles.column} >
-            <div className={ModalStyles.wrapper} >
-              <div className={ModalStyles.sectionTitle} >
+                </ul>
+              </div>
+            </div>
+            <div className={ModalStyles.wrapper}>
+              <ColorPicker
+                id={'filter-color'}
+                color={this.props.currentlyEditedFilterGroup.color}
+                onColorChange={this.props.onColorChanged}
+              />
+            </div>
+          </div>
+          <div className={ModalStyles.column}>
+            <div className={ModalStyles.wrapper}>
+              <div className={ModalStyles.sectionTitle}>
                 Filter by:
-              </div >
-              {this.renderFilterList()}
-            </div >
-            <div className={ModalStyles.wrapper} >
-              <div className={ModalStyles.sectionTitle} >
-                <label htmlFor="name" >Name</label >
+              </div>
+              {filtersList}
+            </div>
+            <div className={ModalStyles.wrapper}>
+              <div className={ModalStyles.sectionTitle}>
+                <label htmlFor="name" >Name</label>
               </div >
               <input
                 type="text"
                 name="name"
-                onChange={this.onNameChange}
+                onChange={(event) => { this.props.onLabelChanged(event.target.value); }}
                 className={ModalStyles.nameInput}
                 placeholder="Filter Group Name"
-                value={this.state.filterGroup.label}
+                value={this.props.label}
               />
-            </div >
-          </div >
-        </div >
-        <div className={ModalStyles.footerContainer} >
+            </div>
+          </div>
+        </div>
+        <div className={ModalStyles.footerContainer}>
           <button
             className={classnames(
               ButtonStyles.button, ButtonStyles._filled,
               ButtonStyles._big, ModalStyles.mainButton, {
-                [ButtonStyles._disabled]: disableSave
+                [ButtonStyles._disabled]: this.props.disableSave
               })}
-            onClick={this.onPressSave}
+            onClick={this.props.onSaveClicked}
           >
             Save
-          </button >
-        </div >
-      </div >
+          </button>
+        </div>
+      </div>
     );
   }
 }
 
 FilterGroupForm.propTypes = {
-  editFilterGroupIndex: PropTypes.number,
   layers: PropTypes.array,
-  filterGroup: PropTypes.object,
-  saveFilterGroup: PropTypes.func,
-  openLayerInfoModal: PropTypes.func.isRequired,
-  defaultColorIndex: PropTypes.number
+  currentlyEditedFilterGroup: PropTypes.object,
+  filters: PropTypes.array,
+  defaultLabel: PropTypes.string,
+  label: PropTypes.string,
+  disableSave: PropTypes.bool,
+  onLayerChecked: PropTypes.func,
+  onColorChanged: PropTypes.func,
+  onFilterValueChanged: PropTypes.func,
+  onLabelChanged: PropTypes.func,
+  onSaveClicked: PropTypes.func,
+  openLayerInfoModal: PropTypes.func
 };
 
 export default FilterGroupForm;

--- a/app/src/filters/components/FilterGroupPanel.jsx
+++ b/app/src/filters/components/FilterGroupPanel.jsx
@@ -2,11 +2,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import cloneDeep from 'lodash/cloneDeep';
-import platform from 'platform';
 import FilterGroupItem from 'filters/containers/FilterGroupItem';
-import { FLAGS, FLAGS_SHORTCODES, FLAGS_LANDLOCKED } from 'constants';
-import iso3311a2 from 'iso-3166-1-alpha-2';
 import classnames from 'classnames';
 import flagFilterStyles from 'styles/components/map/flag-filters.scss';
 import buttonStyles from 'styles/components/button.scss';
@@ -17,80 +13,9 @@ class FilterGroupPanel extends Component {
     this.state = { currentBlendingOptionsShown: -1 };
   }
 
-  componentWillMount() {
-    this.countryOptions = this.getCountryOptions();
-  }
-
-  getCountryOptions() {
-    const countryNames = [];
-    const countryOptions = [];
-
-    Object.keys(FLAGS)
-      .filter(key => FLAGS_LANDLOCKED.indexOf(FLAGS[key]) === -1)
-      .forEach((index) => {
-        if (iso3311a2.getCountry(FLAGS[index])) {
-          const countryCode = FLAGS[index];
-          const iconAsciiCodePoints = FLAGS_SHORTCODES[countryCode.toLowerCase()];
-          countryNames.push({
-            name: iso3311a2.getCountry(countryCode),
-            icon: String.fromCodePoint.apply(null, iconAsciiCodePoints),
-            id: index
-          });
-        }
-      });
-
-    countryNames.sort((a, b) => {
-      if (a.name > b.name) {
-        return 1;
-      }
-
-      if (b.name > a.name) {
-        return -1;
-      }
-
-      return 0;
-    });
-
-    countryOptions.push(<option key="" value="" >All countries</option >);
-
-    const supportsEmojiFlags =
-      ['iOS', 'OS X'].indexOf(platform.os.family) > -1 ||
-      platform.os.toString().match('Windows 10');
-
-    countryNames.forEach((country) => {
-      const label = (supportsEmojiFlags) ? `${country.name} ${country.icon}` : country.name;
-      countryOptions.push(<option key={country.id} value={country.id} >{label}</option >);
-    });
-
-    return countryOptions;
-  }
-
-  updateFilters(filter, index) {
-    const updatedFilters = cloneDeep(this.props.filterGroups);
-    if (!updatedFilters[index]) return;
-    updatedFilters[index] = Object.assign({}, updatedFilters[index], filter);
-    if (filter.hue === undefined) {
-      this.hideBlending();
-    }
-  }
-
   addFilterGroup() {
     this.hideBlending(); // TODO: replace with logic to hide quick edits and such
     this.props.createFilterGroup();
-  }
-
-  removeFilter(index) {
-    const filters = cloneDeep(this.props.filterGroups);
-    filters.splice(index, 1);
-    this.hideBlending();
-  }
-
-  onLayerBlendingToggled(layerIndex) {
-    let currentBlendingOptionsShown = layerIndex;
-    if (currentBlendingOptionsShown === this.state.currentBlendingOptionsShown) {
-      currentBlendingOptionsShown = -1;
-    }
-    this.setState({ currentBlendingOptionsShown });
   }
 
   hideBlending() {

--- a/app/src/filters/containers/FilterGroupForm.js
+++ b/app/src/filters/containers/FilterGroupForm.js
@@ -1,24 +1,81 @@
 import { connect } from 'react-redux';
 import FilterGroupForm from 'filters/components/FilterGroupForm';
-import { setFilterGroupModalVisibility, saveFilterGroup, setEditFilterGroupIndex } from 'filters/filterGroupsActions';
-import { LAYER_TYPES } from 'constants';
+import {
+  setCurrentFilterGroupActiveLayer,
+  setCurrentFilterGroupColor,
+  setCurrentFilterValue,
+  setCurrentFilterGroupLabel,
+  saveFilterGroup,
+  setFilterGroupModalVisibility
+} from 'filters/filterGroupsActions';
 import { setLayerInfoModal } from 'actions/map';
+import { LAYER_TYPES, FLAG_FILTER_GROUP_VALUES } from 'constants';
 
 const mapStateToProps = (state) => {
-  const editFilterGroupIndex = state.filterGroups.editFilterGroupIndex;
+  const currentlyEditedFilterGroup = state.filterGroups.currentlyEditedFilterGroup;
+
+  // prepare layers list for component, add a filterActivated prop to set checkbox status
+  const layers = state.layers.workspaceLayers.filter(elem => elem.type === LAYER_TYPES.Heatmap).map((l) => {
+    l.filterActivated = currentlyEditedFilterGroup.checkedLayers[l.id] === true;
+    return l;
+  });
+
+  // prepare filters: dedupe filters that have the same id, set default values
+  const availableFilters = layers.filter(l => l.filterActivated === true).map(l => l.header.filters);
+  const flattenedFilters = [].concat(...availableFilters);
+  const filtersById = {};
+  // this will remove duplicates by filter.id (ie category / flag_id)
+  flattenedFilters.forEach((f) => {
+    filtersById[f.id] = f;
+    if (f.useDefaultValues === true) {
+      if (f.id === 'flag') {
+        filtersById[f.id].values = FLAG_FILTER_GROUP_VALUES;
+      }
+    }
+  });
+  const filters = Object.values(filtersById);
+
+  // take all the displayed labels to set default filter group label
+  const defaultLabel = (!filters.length) ? '' : Object.keys(currentlyEditedFilterGroup.filterValues).map((filterId) => {
+    const currentFilterValue = currentlyEditedFilterGroup.filterValues[filterId];
+    const filterValues = filters.find(filter => filter.id === filterId).values;
+    const filterValueLabel = filterValues.find(filterValue => parseInt(filterValue.id, 10) === currentFilterValue).label;
+    return filterValueLabel;
+  }).join(' ');
+  // const label = (defaultName === currentlyEditedFilterGroup.label || ) ? defaultName : currentlyEditedFilterGroup.label;
+
+  // prepare save button status: at least one layer must be checked, and at least one filter defined
+  const anyLayerChecked = Object.keys(currentlyEditedFilterGroup.checkedLayers)
+    .some(key => currentlyEditedFilterGroup.checkedLayers[key] === true);
+  const anyFilterSelected = Object.keys(currentlyEditedFilterGroup.filterValues).length > 0;
+  const disableSave = anyLayerChecked === false || anyFilterSelected === false;
+
   return {
-    layers: state.layers.workspaceLayers.filter(elem => elem.type === LAYER_TYPES.Heatmap),
-    filterGroup: editFilterGroupIndex !== null ? state.filterGroups.filterGroups[editFilterGroupIndex] : {},
-    editFilterGroupIndex,
-    defaultColorIndex: state.filterGroups.defaultColorIndex
+    layers,
+    currentlyEditedFilterGroup,
+    filters,
+    label: currentlyEditedFilterGroup.label,
+    defaultLabel,
+    disableSave
   };
 };
 
 const mapDispatchToProps = dispatch => ({
-  saveFilterGroup: (filterGroup, index) => {
+  onLayerChecked: (layerId) => {
+    dispatch(setCurrentFilterGroupActiveLayer(layerId));
+  },
+  onColorChanged: (color) => {
+    dispatch(setCurrentFilterGroupColor(color));
+  },
+  onLabelChanged: (label) => {
+    dispatch(setCurrentFilterGroupLabel(label));
+  },
+  onFilterValueChanged: (id, value) => {
+    dispatch(setCurrentFilterValue(id, value));
+  },
+  onSaveClicked: () => {
     dispatch(setFilterGroupModalVisibility(false));
-    dispatch(saveFilterGroup(filterGroup, index));
-    dispatch(setEditFilterGroupIndex(null));
+    dispatch(saveFilterGroup());
   },
   openLayerInfoModal: (modalParams) => {
     dispatch(setLayerInfoModal(modalParams));

--- a/app/src/filters/containers/FilterGroupPanel.js
+++ b/app/src/filters/containers/FilterGroupPanel.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import FilterGroupPanel from 'filters/components/FilterGroupPanel';
-import { setFilterGroupModalVisibility } from 'filters/filterGroupsActions';
+import { setFilterGroupModalVisibility, createNewFilterGroup } from 'filters/filterGroupsActions';
 
 
 const mapStateToProps = state => ({
@@ -9,6 +9,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   createFilterGroup: () => {
+    dispatch(createNewFilterGroup());
     dispatch(setFilterGroupModalVisibility(true));
   }
 });

--- a/app/src/filters/filterGroupsActions.js
+++ b/app/src/filters/filterGroupsActions.js
@@ -1,14 +1,42 @@
 import { LAYER_TYPES } from 'constants';
-import { COLOR_HUES } from 'config';
+import { COLOR_HUES, COLORS } from 'config';
 import { trackCreateFilterGroups } from 'analytics/analyticsActions';
 
+export const CREATE_NEW_FILTER_GROUP = 'CREATE_NEW_FILTER_GROUP';
 export const SAVE_FILTER_GROUP = 'SAVE_FILTER_GROUP';
 export const SET_FILTER_GROUP_MODAL_VISIBILITY = 'SET_FILTER_GROUP_MODAL_VISIBILITY';
 export const SET_FILTER_GROUP_VISIBILITY = 'SET_FILTER_GROUP_VISIBILITY';
 export const SET_EDIT_FILTER_GROUP_INDEX = 'SET_EDIT_FILTER_GROUP_INDEX';
 export const DELETE_FILTER_GROUP = 'DELETE_FILTER_GROUP';
 export const SET_FILTER_GROUPS = 'SET_FILTER_GROUPS';
-export const SET_DEFAULT_COLOR = 'SET_DEFAULT_COLOR';
+export const SET_CURRENT_FILTER_GROUP_ACTIVE_LAYER = 'SET_CURRENT_FILTER_GROUP_ACTIVE_LAYER';
+export const SET_CURRENT_FILTER_GROUP_COLOR = 'SET_CURRENT_FILTER_GROUP_COLOR';
+export const SET_CURRENT_FILTER_GROUP_LABEL = 'SET_CURRENT_FILTER_GROUP_LABEL';
+export const SET_CURRENT_FILTER_VALUE = 'SET_CURRENT_FILTER_VALUE';
+
+export function createNewFilterGroup() {
+  return (dispatch, getState) => {
+    const checkedLayers = {};
+    getState().layers.workspaceLayers.filter(elem => elem.type === LAYER_TYPES.Heatmap).map(l => l.id).forEach((lid) => {
+      checkedLayers[lid] = true;
+    });
+
+    const newFilterGroup = {
+      checkedLayers,
+      color: Object.keys(COLORS)[getState().filterGroups.defaultColorIndex],
+      filterValues: {},
+      visible: true,
+      label: ''
+    };
+
+    dispatch({
+      type: CREATE_NEW_FILTER_GROUP,
+      payload: {
+        newFilterGroup
+      }
+    });
+  };
+}
 
 export function setEditFilterGroupIndex(editFilterGroupIndex) {
   return {
@@ -35,10 +63,23 @@ const getLayerData = (heatmapLayer, filters) => {
   filters
     .filter(f => f.visible === true)
     .filter(f => f.checkedLayers[heatmapLayer.id] === true)
-    .forEach((filter) => {
+    .forEach((filterGroup) => {
+      const filterValues = {};
+      Object.keys(filterGroup.filterValues).forEach((filterValueKey) => {
+        // set actual field name usable on layer, from filter id (ie id:flag --> filterValue:category or filterValue:flag_id)
+        const originalLayerHeaderFilter = heatmapLayer.header.filters.find(layerHeaderFilter => layerHeaderFilter.id === filterValueKey);
+        // check if filter is supported in layer header
+        if (originalLayerHeaderFilter !== undefined) {
+          const fieldName = originalLayerHeaderFilter.field;
+          filterValues[fieldName] = filterGroup.filterValues[filterValueKey];
+        }
+      });
       const layerGroupedFilter = {
-        hue: COLOR_HUES[filter.color],
-        filterValues: filter.filterValues
+        hue: COLOR_HUES[filterGroup.color],
+        filterValues,
+        // that happens when none of the filters fields in the filter group is supported by the layer headers
+        // 'pass' will be handled by HeatmapLayer
+        pass: Object.keys(filterValues).length === 0
       };
       layerGroupedFilters.push(layerGroupedFilter);
     });
@@ -53,20 +94,16 @@ const getLayerData = (heatmapLayer, filters) => {
  * through GLContainer and HeatmapLayer
  * Then is filtered in the _dumpTileVessels method of HeatmapSublayer
  *
- * @param {array} initialFilters - the original filters to process
- * @returns {array} filters - Filters to save in the store and workspace
  * @returns {array} layerFilters - Filters grouped by layer
  */
 
-export function setFilterGroups(initialFilters) {
+export function setLayerFilters() {
   return (dispatch, getState) => {
     // Get heatmap layers and organise filters to have one sublayer per heatmapLayer
     const heatmapLayers = getState().layers.workspaceLayers.filter(layer =>
       layer.type === LAYER_TYPES.Heatmap && layer.added === true
     );
-    // slice(0) clones an array
-    const filters = (initialFilters === undefined) ? [{}] : initialFilters.slice(0);
-    filters.filter(f => Object.keys(f).length !== 0); // remove empty filters
+    const filters = getState().filterGroups.filterGroups;
 
     const layerFilters = {};
     heatmapLayers.forEach((heatmapLayer) => {
@@ -76,46 +113,44 @@ export function setFilterGroups(initialFilters) {
     dispatch({
       type: SET_FILTER_GROUPS,
       payload: {
-        filters,
         layerFilters
       }
     });
   };
 }
 
-export function saveFilterGroup(filterGroup, index = null) {
+export function saveFilterGroup(filterGroup = null) {
   return (dispatch, getState) => {
+    // if filterGroup is not set, use the currently edited one
+    const newFilterGroup = filterGroup || Object.assign({}, getState().filterGroups.currentlyEditedFilterGroup);
+
     // Send analytics only if new filter is created (index === null)
-    if (index === null) {
-      dispatch(trackCreateFilterGroups(filterGroup));
-      dispatch({
-        type: SET_DEFAULT_COLOR
-      });
+    if (getState().filterGroups.editFilterGroupIndex === null) {
+      dispatch(trackCreateFilterGroups(newFilterGroup));
     }
 
     dispatch({
       type: SAVE_FILTER_GROUP,
       payload: {
-        filterGroup,
-        index
+        filterGroup: newFilterGroup
       }
     });
-    dispatch(setFilterGroups(getState().filterGroups.filterGroups));
+    dispatch(setLayerFilters());
   };
 }
 
 export function deleteFilterGroup(index) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch({
       type: DELETE_FILTER_GROUP,
       payload: index
     });
-    dispatch(setFilterGroups(getState().filterGroups.filterGroups));
+    dispatch(setLayerFilters());
   };
 }
 
 export function toggleFilterGroupVisibility(index, forceValue = null) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     dispatch({
       type: SET_FILTER_GROUP_VISIBILITY,
       payload: {
@@ -123,12 +158,40 @@ export function toggleFilterGroupVisibility(index, forceValue = null) {
         forceValue
       }
     });
-    dispatch(setFilterGroups(getState().filterGroups.filterGroups));
+    dispatch(setLayerFilters());
   };
 }
 
 export function refreshFlagFiltersLayers() {
-  return (dispatch, getState) => {
-    dispatch(setFilterGroups(getState().filterGroups.filterGroups));
+  return (dispatch) => {
+    dispatch(setLayerFilters());
+  };
+}
+
+export function setCurrentFilterGroupActiveLayer(layerId) {
+  return {
+    type: SET_CURRENT_FILTER_GROUP_ACTIVE_LAYER,
+    payload: { layerId }
+  };
+}
+
+export function setCurrentFilterGroupColor(color) {
+  return {
+    type: SET_CURRENT_FILTER_GROUP_COLOR,
+    payload: { color }
+  };
+}
+
+export function setCurrentFilterGroupLabel(label) {
+  return {
+    type: SET_CURRENT_FILTER_GROUP_LABEL,
+    payload: { label }
+  };
+}
+
+export function setCurrentFilterValue(id, value) {
+  return {
+    type: SET_CURRENT_FILTER_VALUE,
+    payload: { id, value }
   };
 }

--- a/app/src/filters/filterGroupsActions.js
+++ b/app/src/filters/filterGroupsActions.js
@@ -93,8 +93,6 @@ const getLayerData = (heatmapLayer, filters) => {
  * A sublayer is created for each layerFilters information
  * through GLContainer and HeatmapLayer
  * Then is filtered in the _dumpTileVessels method of HeatmapSublayer
- *
- * @returns {array} layerFilters - Filters grouped by layer
  */
 
 export function setLayerFilters() {

--- a/app/src/filters/filterGroupsReducer.js
+++ b/app/src/filters/filterGroupsReducer.js
@@ -1,32 +1,60 @@
 import { SET_FILTER_GROUP_MODAL_VISIBILITY, SAVE_FILTER_GROUP, SET_FILTER_GROUP_VISIBILITY } from 'filters/filtersActions';
-import { SET_EDIT_FILTER_GROUP_INDEX, DELETE_FILTER_GROUP, SET_FILTER_GROUPS, SET_DEFAULT_COLOR } from 'filters/filterGroupsActions';
+import {
+  CREATE_NEW_FILTER_GROUP,
+  SET_EDIT_FILTER_GROUP_INDEX,
+  DELETE_FILTER_GROUP,
+  SET_FILTER_GROUPS,
+  SET_CURRENT_FILTER_GROUP_ACTIVE_LAYER,
+  SET_CURRENT_FILTER_GROUP_COLOR,
+  SET_CURRENT_FILTER_GROUP_LABEL,
+  SET_CURRENT_FILTER_VALUE
+} from 'filters/filterGroupsActions';
 import { COLORS } from 'config';
 
 const initialState = {
+  // the filters - structure matches how filters are visually presented
   filterGroups: [],
+  // a list of filters organized by layers
+  layerFilters: [],
+  // the filter group currently edited in the modal
+  currentlyEditedFilterGroup: null,
+  // filterGroups' index of the filter group currently edited in the modal
   editFilterGroupIndex: null,
-  isFilterGroupModalOpen: false,
   // the color that is selected by default when opening a new filter group modal
-  defaultColorIndex: 0
+  defaultColorIndex: 0,
+  isFilterGroupModalOpen: false
 };
 
 export default function (state = initialState, action) {
   switch (action.type) {
+    case CREATE_NEW_FILTER_GROUP: {
+      return Object.assign({}, state, {
+        currentlyEditedFilterGroup: action.payload.newFilterGroup,
+        editFilterGroupIndex: null,
+        defaultColorIndex: (state.defaultColorIndex === Object.keys(COLORS).length - 1) ? 0 : state.defaultColorIndex + 1
+      });
+    }
     case SET_EDIT_FILTER_GROUP_INDEX: {
-      return Object.assign({}, state, { editFilterGroupIndex: action.payload });
+      const editFilterGroupIndex = action.payload;
+      const currentlyEditedFilterGroup =
+        (editFilterGroupIndex === null) ? null : Object.assign({}, state.filterGroups[editFilterGroupIndex]);
+      return Object.assign({}, state, {
+        editFilterGroupIndex,
+        currentlyEditedFilterGroup
+      });
     }
     case SET_FILTER_GROUP_MODAL_VISIBILITY: {
       return Object.assign({}, state, { isFilterGroupModalOpen: action.payload });
     }
     case SAVE_FILTER_GROUP: {
-      const index = action.payload.index;
-      let newFilterGroup;
+      const index = state.editFilterGroupIndex;
+      let newFilterGroups;
       if (index !== null) {
-        newFilterGroup = [...state.filterGroups.slice(0, index), action.payload.filterGroup, ...state.filterGroups.slice(index + 1)];
+        newFilterGroups = [...state.filterGroups.slice(0, index), action.payload.filterGroup, ...state.filterGroups.slice(index + 1)];
       } else {
-        newFilterGroup = [...state.filterGroups, action.payload.filterGroup];
+        newFilterGroups = [...state.filterGroups, action.payload.filterGroup];
       }
-      return Object.assign({}, state, { filterGroups: newFilterGroup });
+      return Object.assign({}, state, { filterGroups: newFilterGroups });
     }
     case SET_FILTER_GROUP_VISIBILITY: {
       const { index, forceValue } = action.payload;
@@ -55,9 +83,36 @@ export default function (state = initialState, action) {
         filters, layerFilters
       });
     }
-    case SET_DEFAULT_COLOR: {
+    case SET_CURRENT_FILTER_GROUP_ACTIVE_LAYER: {
+      const currentlyEditedFilterGroup = Object.assign({}, state.currentlyEditedFilterGroup);
+      currentlyEditedFilterGroup.checkedLayers[action.payload.layerId] = !currentlyEditedFilterGroup.checkedLayers[action.payload.layerId];
       return Object.assign({}, state, {
-        defaultColorIndex: (state.defaultColorIndex === Object.keys(COLORS).length - 1) ? 0 : state.defaultColorIndex + 1
+        currentlyEditedFilterGroup
+      });
+    }
+    case SET_CURRENT_FILTER_GROUP_COLOR: {
+      const currentlyEditedFilterGroup = Object.assign({}, state.currentlyEditedFilterGroup);
+      currentlyEditedFilterGroup.color = action.payload.color;
+      return Object.assign({}, state, {
+        currentlyEditedFilterGroup
+      });
+    }
+    case SET_CURRENT_FILTER_GROUP_LABEL: {
+      const currentlyEditedFilterGroup = Object.assign({}, state.currentlyEditedFilterGroup);
+      currentlyEditedFilterGroup.label = action.payload.label;
+      return Object.assign({}, state, {
+        currentlyEditedFilterGroup
+      });
+    }
+    case SET_CURRENT_FILTER_VALUE: {
+      const currentlyEditedFilterGroup = Object.assign({}, state.currentlyEditedFilterGroup);
+      if (action.payload.value === '') {
+        delete currentlyEditedFilterGroup.filterValues[action.payload.id];
+      } else {
+        currentlyEditedFilterGroup.filterValues[action.payload.id] = parseInt(action.payload.value, 10);
+      }
+      return Object.assign({}, state, {
+        currentlyEditedFilterGroup
       });
     }
     default:

--- a/app/src/filters/filterGroupsReducer.js
+++ b/app/src/filters/filterGroupsReducer.js
@@ -15,7 +15,7 @@ const initialState = {
   // the filters - structure matches how filters are visually presented
   filterGroups: [],
   // a list of filters organized by layers
-  layerFilters: [],
+  layerFilters: {},
   // the filter group currently edited in the modal
   currentlyEditedFilterGroup: null,
   // filterGroups' index of the filter group currently edited in the modal

--- a/app/src/filters/filtersActions.js
+++ b/app/src/filters/filtersActions.js
@@ -1,6 +1,5 @@
 import { GA_PLAY_STATUS_TOGGLED, trackInnerTimelineChange, trackOuterTimelineChange } from 'analytics/analyticsActions';
 import { TIMELINE_MIN_INNER_EXTENT } from 'config';
-import { LAYER_TYPES } from 'constants';
 import { loadTilesExtraTimeRange } from 'actions/heatmap';
 
 export const SET_SPEED = 'SET_SPEED';
@@ -19,56 +18,6 @@ export const SET_TIMELINE_HOVER_DATES = 'SET_TIMELINE_HOVER_DATES';
 
 
 const getRangeDuration = range => range[1].getTime() - range[0].getTime();
-
-/** @deprecated use filterGroups logic instead */
-export function setFlagFilters(flagFilters_) {
-  return (dispatch, getState) => {
-    // get heatmap layers and organise filters to have one sublayer per filter in each layer
-    // if there's only one filter and it's not set, set it to ALL
-    // for the next ones, ignore undefined filters
-    // filter hue overrides heatmap layer hue when set
-    const heatmapLayers = getState().layers.workspaceLayers.filter(layer =>
-      layer.type === LAYER_TYPES.Heatmap && layer.added === true
-    );
-    const flagFilters = (flagFilters_ === undefined) ? [] : flagFilters_.slice(0);
-    const flagFiltersLayers = {};
-    if (!flagFilters.length) {
-      flagFilters.push({});
-    }
-    heatmapLayers.forEach((heatmapLayer) => {
-      const subLayers = [];
-      flagFilters.forEach((flagFilter, index) => {
-        let flag = flagFilter.flag;
-        if (flag === undefined) {
-          if (index === 0) {
-            flag = 'ALL';
-          } else {
-            return;
-          }
-        } else {
-          flag = parseInt(flag, 10);
-        }
-        const hue = (flagFilter.hue !== undefined) ? flagFilter.hue : heatmapLayer.hue;
-        subLayers.push({ flag, hue });
-      });
-      flagFiltersLayers[heatmapLayer.id] = subLayers;
-    });
-    dispatch({
-      type: SET_FLAG_FILTERS,
-      payload: {
-        flagFilters,
-        flagFiltersLayers
-      }
-    });
-  };
-}
-
-/** @deprecated use filterGroups logic instead */
-export function refreshFlagFiltersLayers() {
-  return (dispatch, getState) => {
-    dispatch(setFlagFilters(getState().filters.flags));
-  };
-}
 
 export function setInnerTimelineDates(innerTimelineDates) {
   return (dispatch, getState) => {

--- a/app/src/filters/filtersReducer.js
+++ b/app/src/filters/filtersReducer.js
@@ -33,11 +33,7 @@ const initialState = {
     getOffsetedTimeAtPrecision(TIMELINE_DEFAULT_INNER_END_DATE.getTime())
   ],
   timelinePaused: true,
-  timelineSpeed: 1,
-  /** @deprecated use filterGroups logic instead */
-  flagsLayers: {},
-  /** @deprecated use filterGroups logic instead */
-  flags: []
+  timelineSpeed: 1
 };
 
 export default function (state = initialState, action) {

--- a/app/src/layers/layersActions.js
+++ b/app/src/layers/layersActions.js
@@ -4,9 +4,7 @@ import { SET_OVERALL_TIMELINE_DATES } from 'filters/filtersActions';
 import { refreshFlagFiltersLayers } from 'filters/filterGroupsActions';
 import { initHeatmapLayers, addHeatmapLayerFromLibrary, removeHeatmapLayerFromLibrary, loadAllTilesForLayer } from 'actions/heatmap';
 import calculateLayerId from 'util/calculateLayerId';
-// TODO: Remove this when legacy AIS layers contain filter category in headers (+2 more comments in this file)->
-import { AIS_LAYER_ID } from 'config';
-// <-
+
 export const SET_MAX_ZOOM = 'SET_MAX_ZOOM';
 export const SET_LAYERS = 'SET_LAYERS';
 export const SET_LAYER_HEADER = 'SET_LAYER_HEADER';
@@ -129,22 +127,9 @@ export function initLayers(workspaceLayers, libraryLayers) {
       .forEach((heatmapLayer) => {
         const headerPromise = loadLayerHeader(heatmapLayer.url, getState().user.token);
         headerPromise.then((header) => {
-          // Remove this when legacy AIS layers contain filter category in headers ->
-          const defaultFilter = {
-            field: 'category',
-            id: 'flag',
-            label: 'Country',
-            useDefaultValues: true
-          };
-          // <-
           if (header !== null) {
             heatmapLayer.header = header;
             dispatch(setGlobalFiltersFromHeader(header));
-            // Remove this when legacy AIS layers contain filter category in headers ->
-            if (heatmapLayer.id === AIS_LAYER_ID && header.filters === undefined) {
-              header.filters = [defaultFilter];
-            }
-            // <-
           }
         });
         headersPromises.push(headerPromise);

--- a/app/src/util/getFlagFilterGroupValues.js
+++ b/app/src/util/getFlagFilterGroupValues.js
@@ -1,11 +1,8 @@
-import platform from 'platform';
 import { FLAGS, FLAGS_SHORTCODES, FLAGS_LANDLOCKED } from 'app/src/constants';
 import iso3311a2 from 'iso-3166-1-alpha-2';
-import React from 'react';
 
 export default () => {
   const countryNames = [];
-  const countryOptions = [];
 
   Object.keys(FLAGS)
     .filter(key => FLAGS_LANDLOCKED.indexOf(FLAGS[key]) === -1)
@@ -14,7 +11,7 @@ export default () => {
         const countryCode = FLAGS[index];
         const iconAsciiCodePoints = FLAGS_SHORTCODES[countryCode.toLowerCase()];
         countryNames.push({
-          name: iso3311a2.getCountry(countryCode),
+          label: iso3311a2.getCountry(countryCode),
           icon: String.fromCodePoint.apply(null, iconAsciiCodePoints),
           id: index
         });
@@ -22,27 +19,16 @@ export default () => {
     });
 
   countryNames.sort((a, b) => {
-    if (a.name > b.name) {
+    if (a.label > b.label) {
       return 1;
     }
 
-    if (b.name > a.name) {
+    if (b.label > a.label) {
       return -1;
     }
 
     return 0;
   });
 
-  countryOptions.push(<option key="" value="" >All countries</option >);
-
-  const supportsEmojiFlags =
-    ['iOS', 'OS X'].indexOf(platform.os.family) > -1 ||
-    platform.os.toString().match('Windows 10');
-
-  countryNames.forEach((country) => {
-    const label = (supportsEmojiFlags) ? `${country.name} ${country.icon}` : country.name;
-    countryOptions.push(<option key={country.id} value={country.id} >{label}</option >);
-  });
-
-  return countryOptions;
+  return countryNames;
 };


### PR DESCRIPTION
- removed duplicated logic in FilterGroupForm. The container now has logic to prepare the data coming from the stores for the component to render.
- made FilterGroupForm a dumb component: it doesn't handle its own state, and directly calls actions on the store for every modification of the currently edited filter.
- creating a new filter group, with initial state, has an explicit action in the actions rather than inside the component
- added support for aliasing filters (ie filters that have the same id but apply to a different field depending on the layers, for example flag --> flag_id or category)
- moved flag options generation code to an util, they are now generated once in a constant
- removed legacy filter code as well as support for headers without filter information (default filter generation)